### PR TITLE
feat: assigned tests UX for student + AI report for psychologist

### DIFF
--- a/drizzle/0003_faulty_captain_stacy.sql
+++ b/drizzle/0003_faulty_captain_stacy.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "diagnostic_ai_reports" (
+	"id" text PRIMARY KEY NOT NULL,
+	"session_id" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"model" text,
+	"summary" text,
+	"interpretation" text,
+	"risk_factors" jsonb,
+	"recommendations" jsonb,
+	"trend" text,
+	"flagged_items" jsonb,
+	"tokens_used" integer,
+	"error_message" text,
+	"generated_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "diagnostic_ai_reports_session_id_unique" UNIQUE("session_id")
+);
+--> statement-breakpoint
+ALTER TABLE "diagnostic_ai_reports" ADD CONSTRAINT "diagnostic_ai_reports_session_id_diagnostic_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."diagnostic_sessions"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,2232 @@
+{
+  "id": "bdc17940-3110-416b-bc43-ea3bc2b2dfcd",
+  "prevId": "c7148b36-a663-488f-9a29-e3f309d5ae84",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.achievements": {
+      "name": "achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_ru": {
+          "name": "name_ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_kz": {
+          "name": "name_kz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_ru": {
+          "name": "description_ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_kz": {
+          "name": "description_kz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "achievements_slug_unique": {
+          "name": "achievements_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointment_slots": {
+      "name": "appointment_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "psychologist_id": {
+          "name": "psychologist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_booked": {
+          "name": "is_booked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointment_slots_psychologist_id_users_id_fk": {
+          "name": "appointment_slots_psychologist_id_users_id_fk",
+          "tableFrom": "appointment_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "psychologist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "psychologist_id": {
+          "name": "psychologist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "student_note": {
+          "name": "student_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "psychologist_note": {
+          "name": "psychologist_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointments_slot_id_appointment_slots_id_fk": {
+          "name": "appointments_slot_id_appointment_slots_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "appointment_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_student_id_users_id_fk": {
+          "name": "appointments_student_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "appointments_psychologist_id_users_id_fk": {
+          "name": "appointments_psychologist_id_users_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "psychologist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cbt_entries": {
+      "name": "cbt_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cbt_entries_user_id_users_id_fk": {
+          "name": "cbt_entries_user_id_users_id_fk",
+          "tableFrom": "cbt_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_messages_session_id_chat_sessions_id_fk": {
+          "name": "chat_messages_session_id_chat_sessions_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_sessions": {
+      "name": "chat_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chat_sessions_user_id_users_id_fk": {
+          "name": "chat_sessions_user_id_users_id_fk",
+          "tableFrom": "chat_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_quotes": {
+      "name": "content_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "text_ru": {
+          "name": "text_ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_kz": {
+          "name": "text_kz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "psychologist_id": {
+          "name": "psychologist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_student_id_users_id_fk": {
+          "name": "conversations_student_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "conversations_psychologist_id_users_id_fk": {
+          "name": "conversations_psychologist_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "psychologist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "conversations_student_id_psychologist_id_unique": {
+          "name": "conversations_student_id_psychologist_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id",
+            "psychologist_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diagnostic_ai_reports": {
+      "name": "diagnostic_ai_reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interpretation": {
+          "name": "interpretation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_factors": {
+          "name": "risk_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trend": {
+          "name": "trend",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flagged_items": {
+          "name": "flagged_items",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "diagnostic_ai_reports_session_id_diagnostic_sessions_id_fk": {
+          "name": "diagnostic_ai_reports_session_id_diagnostic_sessions_id_fk",
+          "tableFrom": "diagnostic_ai_reports",
+          "tableTo": "diagnostic_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "diagnostic_ai_reports_session_id_unique": {
+          "name": "diagnostic_ai_reports_session_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diagnostic_answers": {
+      "name": "diagnostic_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_index": {
+          "name": "question_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "diagnostic_answers_session_id_diagnostic_sessions_id_fk": {
+          "name": "diagnostic_answers_session_id_diagnostic_sessions_id_fk",
+          "tableFrom": "diagnostic_answers",
+          "tableTo": "diagnostic_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diagnostic_sessions": {
+      "name": "diagnostic_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "diagnostic_sessions_user_id_users_id_fk": {
+          "name": "diagnostic_sessions_user_id_users_id_fk",
+          "tableFrom": "diagnostic_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "diagnostic_sessions_test_id_diagnostic_tests_id_fk": {
+          "name": "diagnostic_sessions_test_id_diagnostic_tests_id_fk",
+          "tableFrom": "diagnostic_sessions",
+          "tableTo": "diagnostic_tests",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "diagnostic_sessions_assignment_id_test_assignments_id_fk": {
+          "name": "diagnostic_sessions_assignment_id_test_assignments_id_fk",
+          "tableFrom": "diagnostic_sessions",
+          "tableTo": "test_assignments",
+          "columnsFrom": [
+            "assignment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.diagnostic_tests": {
+      "name": "diagnostic_tests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_ru": {
+          "name": "name_ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_kz": {
+          "name": "name_kz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questions": {
+          "name": "questions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scoring_rules": {
+          "name": "scoring_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_count": {
+          "name": "question_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "diagnostic_tests_slug_unique": {
+          "name": "diagnostic_tests_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_id": {
+          "name": "sender_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flagged": {
+          "name": "flagged",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "direct_messages_conversation_id_conversations_id_fk": {
+          "name": "direct_messages_conversation_id_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "direct_messages_sender_id_users_id_fk": {
+          "name": "direct_messages_sender_id_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sender_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercise_completions": {
+      "name": "exercise_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_id": {
+          "name": "exercise_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exercise_completions_user_id_users_id_fk": {
+          "name": "exercise_completions_user_id_users_id_fk",
+          "tableFrom": "exercise_completions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "exercise_completions_exercise_id_exercises_id_fk": {
+          "name": "exercise_completions_exercise_id_exercises_id_fk",
+          "tableFrom": "exercise_completions",
+          "tableTo": "exercises",
+          "columnsFrom": [
+            "exercise_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exercises": {
+      "name": "exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_ru": {
+          "name": "name_ru",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_kz": {
+          "name": "name_kz",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "exercises_slug_unique": {
+          "name": "exercises_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_codes": {
+      "name": "invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "psychologist_id": {
+          "name": "psychologist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_letter": {
+          "name": "class_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_codes_psychologist_id_users_id_fk": {
+          "name": "invite_codes_psychologist_id_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "psychologist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invite_codes_school_id_schools_id_fk": {
+          "name": "invite_codes_school_id_schools_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invite_codes_used_by_users_id_fk": {
+          "name": "invite_codes_used_by_users_id_fk",
+          "tableFrom": "invite_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invite_codes_code_unique": {
+          "name": "invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_user_id_users_id_fk": {
+          "name": "journal_entries_user_id_users_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mood_entries": {
+      "name": "mood_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "energy": {
+          "name": "energy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sleep_quality": {
+          "name": "sleep_quality",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stress_level": {
+          "name": "stress_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "factors": {
+          "name": "factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mood_entries_user_id_users_id_fk": {
+          "name": "mood_entries_user_id_users_id_fk",
+          "tableFrom": "mood_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.psychologist_notes": {
+      "name": "psychologist_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "psychologist_id": {
+          "name": "psychologist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "psychologist_notes_psychologist_id_users_id_fk": {
+          "name": "psychologist_notes_psychologist_id_users_id_fk",
+          "tableFrom": "psychologist_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "psychologist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "psychologist_notes_student_id_users_id_fk": {
+          "name": "psychologist_notes_student_id_users_id_fk",
+          "tableFrom": "psychologist_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schools": {
+      "name": "schools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sos_events": {
+      "name": "sos_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sos_events_user_id_users_id_fk": {
+          "name": "sos_events_user_id_users_id_fk",
+          "tableFrom": "sos_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "sos_events_resolved_by_users_id_fk": {
+          "name": "sos_events_resolved_by_users_id_fk",
+          "tableFrom": "sos_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "resolved_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.student_psychologist": {
+      "name": "student_psychologist",
+      "schema": "",
+      "columns": {
+        "student_id": {
+          "name": "student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "psychologist_id": {
+          "name": "psychologist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_at": {
+          "name": "assigned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "student_psychologist_student_id_users_id_fk": {
+          "name": "student_psychologist_student_id_users_id_fk",
+          "tableFrom": "student_psychologist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "student_psychologist_psychologist_id_users_id_fk": {
+          "name": "student_psychologist_psychologist_id_users_id_fk",
+          "tableFrom": "student_psychologist",
+          "tableTo": "users",
+          "columnsFrom": [
+            "psychologist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "student_psychologist_student_id_psychologist_id_pk": {
+          "name": "student_psychologist_student_id_psychologist_id_pk",
+          "columns": [
+            "student_id",
+            "psychologist_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_assignments": {
+      "name": "test_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_id": {
+          "name": "test_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_grade": {
+          "name": "target_grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_class_letter": {
+          "name": "target_class_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_student_id": {
+          "name": "target_student_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_assignments_test_id_diagnostic_tests_id_fk": {
+          "name": "test_assignments_test_id_diagnostic_tests_id_fk",
+          "tableFrom": "test_assignments",
+          "tableTo": "diagnostic_tests",
+          "columnsFrom": [
+            "test_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_assignments_assigned_by_users_id_fk": {
+          "name": "test_assignments_assigned_by_users_id_fk",
+          "tableFrom": "test_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "test_assignments_target_student_id_users_id_fk": {
+          "name": "test_assignments_target_student_id_users_id_fk",
+          "tableFrom": "test_assignments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "target_student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_achievements": {
+      "name": "user_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "achievement_id": {
+          "name": "achievement_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "earned_at": {
+          "name": "earned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_achievements_user_id_users_id_fk": {
+          "name": "user_achievements_user_id_users_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_achievements_achievement_id_achievements_id_fk": {
+          "name": "user_achievements_achievement_id_achievements_id_fk",
+          "tableFrom": "user_achievements",
+          "tableTo": "achievements",
+          "columnsFrom": [
+            "achievement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_achievements_user_id_achievement_id_unique": {
+          "name": "user_achievements_user_id_achievement_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "achievement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_plants": {
+      "name": "user_plants",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "growth_points": {
+          "name": "growth_points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stage": {
+          "name": "stage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_watered_at": {
+          "name": "last_watered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_plants_user_id_users_id_fk": {
+          "name": "user_plants_user_id_users_id_fk",
+          "tableFrom": "user_plants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_streaks": {
+      "name": "user_streaks",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "current_streak": {
+          "name": "current_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "longest_streak": {
+          "name": "longest_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_active_date": {
+          "name": "last_active_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "freezes_available": {
+          "name": "freezes_available",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "freeze_used_date": {
+          "name": "freeze_used_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_streaks_user_id_users_id_fk": {
+          "name": "user_streaks_user_id_users_id_fk",
+          "tableFrom": "user_streaks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ru'"
+        },
+        "avatar_id": {
+          "name": "avatar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_letter": {
+          "name": "class_letter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_school_id_schools_id_fk": {
+          "name": "users_school_id_schools_id_fk",
+          "tableFrom": "users",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775477479253,
       "tag": "0002_striped_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1776151210332,
+      "tag": "0003_faulty_captain_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -158,6 +158,32 @@ export const diagnosticAnswers = pgTable("diagnostic_answers", {
   score: integer("score"),
 });
 
+// ── 9a. diagnostic_ai_reports ───────────────────────────────────────
+export const diagnosticAiReports = pgTable("diagnostic_ai_reports", {
+  id: text("id").primaryKey(),
+  sessionId: text("session_id")
+    .notNull()
+    .unique()
+    .references(() => diagnosticSessions.id),
+  status: text("status").notNull().default("pending"), // "pending" | "ready" | "error"
+  model: text("model"),
+  summary: text("summary"),
+  interpretation: text("interpretation"),
+  riskFactors: jsonb("risk_factors"), // [{ factor, severity, evidence }]
+  recommendations: jsonb("recommendations"), // [{ type, text }]
+  trend: text("trend"),
+  flaggedItems: jsonb("flagged_items"), // [{ questionIndex, reason }]
+  tokensUsed: integer("tokens_used"),
+  errorMessage: text("error_message"),
+  generatedAt: timestamp("generated_at", { withTimezone: true }),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
 // ── 10. exercises ───────────────────────────────────────────────────
 export const exercises = pgTable("exercises", {
   id: text("id").primaryKey(),

--- a/packages/backend/src/modules/diagnostics/ai-report.service.ts
+++ b/packages/backend/src/modules/diagnostics/ai-report.service.ts
@@ -1,0 +1,307 @@
+import OpenAI from "openai";
+import { v4 as uuidv4 } from "uuid";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { db } from "../../db/index.js";
+import {
+  diagnosticAiReports,
+  diagnosticAnswers,
+  diagnosticSessions,
+  diagnosticTests,
+  users,
+} from "../../db/schema.js";
+import { env } from "../../config/env.js";
+
+const MODEL = "gpt-4.1-mini";
+
+interface RiskFactor {
+  factor: string;
+  severity: "low" | "moderate" | "high";
+  evidence?: string;
+}
+
+interface Recommendation {
+  type: "therapy" | "exercise" | "referral" | "monitoring" | "conversation";
+  text: string;
+}
+
+interface FlaggedItem {
+  questionIndex: number;
+  reason: string;
+}
+
+interface ReportPayload {
+  summary: string;
+  interpretation: string;
+  riskFactors: RiskFactor[];
+  recommendations: Recommendation[];
+  trend: string | null;
+  flaggedItems: FlaggedItem[];
+}
+
+function getClient(): OpenAI | null {
+  if (!env.OPENAI_API_KEY) return null;
+  return new OpenAI({ apiKey: env.OPENAI_API_KEY });
+}
+
+export const aiReportService = {
+  /**
+   * Find an existing report record for a session, or null.
+   */
+  async findBySessionId(sessionId: string) {
+    const [row] = await db
+      .select()
+      .from(diagnosticAiReports)
+      .where(eq(diagnosticAiReports.sessionId, sessionId))
+      .limit(1);
+    return row ?? null;
+  },
+
+  /**
+   * Create a new report record with status "pending". Idempotent: if a record
+   * already exists for the session, returns it untouched.
+   */
+  async ensurePending(sessionId: string) {
+    const existing = await this.findBySessionId(sessionId);
+    if (existing) return existing;
+    const [created] = await db
+      .insert(diagnosticAiReports)
+      .values({
+        id: uuidv4(),
+        sessionId,
+        status: "pending",
+      })
+      .returning();
+    return created;
+  },
+
+  /**
+   * Mark an existing report back to pending (used for regeneration).
+   */
+  async resetToPending(sessionId: string) {
+    const existing = await this.findBySessionId(sessionId);
+    if (!existing) {
+      return this.ensurePending(sessionId);
+    }
+    const [updated] = await db
+      .update(diagnosticAiReports)
+      .set({
+        status: "pending",
+        errorMessage: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(diagnosticAiReports.sessionId, sessionId))
+      .returning();
+    return updated;
+  },
+
+  /**
+   * Generate an AI report for a completed session. Safe to call in background
+   * (fire-and-forget) — swallows errors by writing them into the report row.
+   */
+  async generateReport(sessionId: string): Promise<void> {
+    try {
+      await this.ensurePending(sessionId);
+
+      const [session] = await db
+        .select()
+        .from(diagnosticSessions)
+        .where(eq(diagnosticSessions.id, sessionId))
+        .limit(1);
+      if (!session) throw new Error("Session not found");
+      if (!session.completedAt) throw new Error("Session is not completed");
+
+      const [test] = await db
+        .select()
+        .from(diagnosticTests)
+        .where(eq(diagnosticTests.id, session.testId))
+        .limit(1);
+      if (!test) throw new Error("Test not found");
+
+      const answers = await db
+        .select()
+        .from(diagnosticAnswers)
+        .where(eq(diagnosticAnswers.sessionId, sessionId))
+        .orderBy(diagnosticAnswers.questionIndex);
+
+      const [student] = await db
+        .select({
+          id: users.id,
+          name: users.name,
+          grade: users.grade,
+          classLetter: users.classLetter,
+        })
+        .from(users)
+        .where(eq(users.id, session.userId))
+        .limit(1);
+
+      // Previous completed sessions of the same test, for trend analysis
+      const history = await db
+        .select({
+          id: diagnosticSessions.id,
+          totalScore: diagnosticSessions.totalScore,
+          maxScore: diagnosticSessions.maxScore,
+          severity: diagnosticSessions.severity,
+          completedAt: diagnosticSessions.completedAt,
+        })
+        .from(diagnosticSessions)
+        .where(
+          and(
+            eq(diagnosticSessions.userId, session.userId),
+            eq(diagnosticSessions.testId, session.testId),
+            sql`${diagnosticSessions.completedAt} IS NOT NULL`,
+            sql`${diagnosticSessions.id} <> ${sessionId}`,
+          ),
+        )
+        .orderBy(desc(diagnosticSessions.completedAt))
+        .limit(5);
+
+      const client = getClient();
+      if (!client) {
+        await db
+          .update(diagnosticAiReports)
+          .set({
+            status: "error",
+            errorMessage: "OPENAI_API_KEY is not configured",
+            updatedAt: new Date(),
+          })
+          .where(eq(diagnosticAiReports.sessionId, sessionId));
+        return;
+      }
+
+      // Build a compact payload for the prompt
+      const questions = (test.questions as Array<{
+        index?: number;
+        textRu?: string;
+        options?: Array<{ value: number; labelRu?: string }>;
+      }>) ?? [];
+
+      const answeredItems = answers.map((a) => {
+        const q = questions.find((x) => (x.index ?? questions.indexOf(x)) === a.questionIndex);
+        const optionLabel = q?.options?.find((o) => o.value === a.answer)?.labelRu;
+        return {
+          questionIndex: a.questionIndex,
+          questionText: q?.textRu ?? null,
+          answerValue: a.answer,
+          answerLabel: optionLabel ?? null,
+          score: a.score,
+        };
+      });
+
+      const userPayload = {
+        test: {
+          slug: test.slug,
+          name: test.nameRu,
+          description: test.description,
+        },
+        student: {
+          name: student?.name ?? null,
+          grade: student?.grade ?? null,
+          classLetter: student?.classLetter ?? null,
+        },
+        result: {
+          totalScore: session.totalScore,
+          maxScore: session.maxScore,
+          severity: session.severity,
+          completedAt: session.completedAt?.toISOString() ?? null,
+        },
+        previousResults: history.map((h) => ({
+          totalScore: h.totalScore,
+          maxScore: h.maxScore,
+          severity: h.severity,
+          completedAt: h.completedAt?.toISOString() ?? null,
+        })),
+        answers: answeredItems,
+      };
+
+      const systemPrompt = `Ты — клинический психолог-ассистент, который помогает школьному психологу интерпретировать результаты психодиагностического теста ученика.
+
+Твоя задача — сгенерировать структурированный отчёт на русском языке.
+
+Требования:
+- Только JSON по указанной схеме, без markdown и лишнего текста.
+- Используй профессиональный, но не пугающий язык.
+- Не ставь диагнозов. Формулируй как "признаки", "симптомы совместимы с", "следует обратить внимание".
+- Рекомендации — практичные, применимые в школьной среде. Типы: "therapy" (индивидуальная беседа), "exercise" (упражнения: дыхание, заземление, дневник), "referral" (направление к специалисту), "monitoring" (наблюдение и повторная оценка), "conversation" (разговор с психологом/родителями).
+- riskFactors.severity: "low" | "moderate" | "high".
+- flaggedItems — это questionIndex тех пунктов, ответы на которые особенно тревожны (например, вопросы о суицидальных мыслях или самоповреждении с высоким значением). Если таких нет — пустой массив.
+- trend: если previousResults непуст — кратко сравни с предыдущей попыткой ("ухудшение", "улучшение", "стабильно"). Если пуст — верни null.
+- summary — 1-2 предложения, самая суть.
+- interpretation — 3-6 предложений с клинической интерпретацией скора и ключевых паттернов в ответах.
+
+Схема JSON:
+{
+  "summary": string,
+  "interpretation": string,
+  "riskFactors": [{ "factor": string, "severity": "low"|"moderate"|"high", "evidence": string }],
+  "recommendations": [{ "type": "therapy"|"exercise"|"referral"|"monitoring"|"conversation", "text": string }],
+  "trend": string | null,
+  "flaggedItems": [{ "questionIndex": number, "reason": string }]
+}`;
+
+      const completion = await client.chat.completions.create({
+        model: MODEL,
+        response_format: { type: "json_object" },
+        temperature: 0.3,
+        messages: [
+          { role: "system", content: systemPrompt },
+          {
+            role: "user",
+            content: JSON.stringify(userPayload),
+          },
+        ],
+      });
+
+      const content = completion.choices[0]?.message?.content ?? "{}";
+      const parsed = JSON.parse(content) as Partial<ReportPayload>;
+
+      const payload: ReportPayload = {
+        summary: typeof parsed.summary === "string" ? parsed.summary : "",
+        interpretation:
+          typeof parsed.interpretation === "string" ? parsed.interpretation : "",
+        riskFactors: Array.isArray(parsed.riskFactors) ? parsed.riskFactors : [],
+        recommendations: Array.isArray(parsed.recommendations)
+          ? parsed.recommendations
+          : [],
+        trend: typeof parsed.trend === "string" ? parsed.trend : null,
+        flaggedItems: Array.isArray(parsed.flaggedItems)
+          ? parsed.flaggedItems
+          : [],
+      };
+
+      const tokensUsed = completion.usage?.total_tokens ?? null;
+
+      await db
+        .update(diagnosticAiReports)
+        .set({
+          status: "ready",
+          model: MODEL,
+          summary: payload.summary,
+          interpretation: payload.interpretation,
+          riskFactors: payload.riskFactors,
+          recommendations: payload.recommendations,
+          trend: payload.trend,
+          flaggedItems: payload.flaggedItems,
+          tokensUsed,
+          errorMessage: null,
+          generatedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(diagnosticAiReports.sessionId, sessionId));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error("[ai-report] generation failed", sessionId, message);
+      try {
+        await db
+          .update(diagnosticAiReports)
+          .set({
+            status: "error",
+            errorMessage: message.slice(0, 1000),
+            updatedAt: new Date(),
+          })
+          .where(eq(diagnosticAiReports.sessionId, sessionId));
+      } catch (writeErr) {
+        console.error("[ai-report] failed to persist error", writeErr);
+      }
+    }
+  },
+};

--- a/packages/backend/src/modules/diagnostics/diagnostics-psychologist.routes.ts
+++ b/packages/backend/src/modules/diagnostics/diagnostics-psychologist.routes.ts
@@ -38,4 +38,53 @@ diagnosticsPsychologistRouter.post("/assign", async (c) => {
   }
 });
 
+// GET /sessions/:sessionId/report - AI-generated report for a session
+diagnosticsPsychologistRouter.get("/sessions/:sessionId/report", async (c) => {
+  try {
+    const sessionId = c.req.param("sessionId");
+    const report = await diagnosticsService.getAiReportForPsychologist(
+      c.var.user.userId,
+      sessionId,
+    );
+    // If still generating, return 202 so the client knows to keep polling.
+    if (report.status === "pending") {
+      return c.json(report, 202);
+    }
+    return c.json(report);
+  } catch (err) {
+    return handleError(c, err);
+  }
+});
+
+// POST /sessions/:sessionId/report/regenerate - trigger a fresh generation
+diagnosticsPsychologistRouter.post(
+  "/sessions/:sessionId/report/regenerate",
+  async (c) => {
+    try {
+      const sessionId = c.req.param("sessionId");
+      const result = await diagnosticsService.regenerateAiReport(
+        c.var.user.userId,
+        sessionId,
+      );
+      return c.json(result, 202);
+    } catch (err) {
+      return handleError(c, err);
+    }
+  },
+);
+
+// GET /sessions/:sessionId/answers - per-item answers with question text
+diagnosticsPsychologistRouter.get("/sessions/:sessionId/answers", async (c) => {
+  try {
+    const sessionId = c.req.param("sessionId");
+    const result = await diagnosticsService.getSessionAnswersForPsychologist(
+      c.var.user.userId,
+      sessionId,
+    );
+    return c.json(result);
+  } catch (err) {
+    return handleError(c, err);
+  }
+});
+
 export { diagnosticsPsychologistRouter };

--- a/packages/backend/src/modules/diagnostics/diagnostics.repository.ts
+++ b/packages/backend/src/modules/diagnostics/diagnostics.repository.ts
@@ -66,6 +66,31 @@ export const diagnosticsRepository = {
     return assignments;
   },
 
+  /**
+   * Returns the most recent session for the user on the given test that was
+   * created at or after the given timestamp. Used to compute the "status" of
+   * a test assignment (not_started | in_progress | completed).
+   */
+  async findLatestSessionSinceForUser(
+    userId: string,
+    testId: string,
+    since: Date,
+  ) {
+    const [row] = await db
+      .select()
+      .from(diagnosticSessions)
+      .where(
+        and(
+          eq(diagnosticSessions.userId, userId),
+          eq(diagnosticSessions.testId, testId),
+          sql`${diagnosticSessions.startedAt} >= ${since.toISOString()}`,
+        ),
+      )
+      .orderBy(desc(diagnosticSessions.startedAt))
+      .limit(1);
+    return row ?? null;
+  },
+
   async createSession(data: {
     id: string;
     userId: string;
@@ -200,6 +225,37 @@ export const diagnosticsRepository = {
       .orderBy(desc(diagnosticSessions.completedAt))
       .limit(pagination.limit)
       .offset(pagination.offset);
+  },
+
+  /**
+   * Returns true if the given psychologist is linked to the student who owns
+   * the session (or if the psychologist is the session owner themselves).
+   */
+  async canPsychologistAccessSession(
+    psychologistId: string,
+    sessionId: string,
+  ) {
+    const [row] = await db
+      .select({
+        sessionUserId: diagnosticSessions.userId,
+        psychologistId: studentPsychologist.psychologistId,
+      })
+      .from(diagnosticSessions)
+      .leftJoin(
+        studentPsychologist,
+        and(
+          eq(studentPsychologist.studentId, diagnosticSessions.userId),
+          eq(studentPsychologist.psychologistId, psychologistId),
+        ),
+      )
+      .where(eq(diagnosticSessions.id, sessionId))
+      .limit(1);
+    if (!row) return { found: false as const };
+    return {
+      found: true as const,
+      linked: Boolean(row.psychologistId),
+      sessionUserId: row.sessionUserId,
+    };
   },
 
   async countSessionsByPsychologist(psychologistId: string, studentId?: string) {

--- a/packages/backend/src/modules/diagnostics/diagnostics.service.ts
+++ b/packages/backend/src/modules/diagnostics/diagnostics.service.ts
@@ -8,6 +8,7 @@ import type { PaginationParams } from "../../shared/pagination.js";
 import { paginated } from "../../shared/pagination.js";
 import { diagnosticsRepository } from "./diagnostics.repository.js";
 import { achievementsService } from "../achievements/achievements.service.js";
+import { aiReportService } from "./ai-report.service.js";
 
 interface ScoringRule {
   min: number;
@@ -54,13 +55,42 @@ export const diagnosticsService = {
         classLetter,
       );
 
+    const now = Date.now();
+
     const testsWithAssignment = await Promise.all(
       assignments.map(async (a) => {
         const test = await diagnosticsRepository.findTestById(a.testId);
+        const latest = await diagnosticsRepository.findLatestSessionSinceForUser(
+          userId,
+          a.testId,
+          a.createdAt,
+        );
+
+        let status: "not_started" | "in_progress" | "completed" = "not_started";
+        let completedSessionId: string | null = null;
+        if (latest) {
+          if (latest.completedAt) {
+            status = "completed";
+            completedSessionId = latest.id;
+          } else {
+            status = "in_progress";
+          }
+        }
+
+        const overdue =
+          status !== "completed" &&
+          a.dueDate !== null &&
+          a.dueDate !== undefined &&
+          new Date(a.dueDate).getTime() < now;
+
         return {
           assignmentId: a.id,
           testId: a.testId,
           dueDate: a.dueDate,
+          status,
+          completedSessionId,
+          overdue,
+          assignedAt: a.createdAt,
           test: test
             ? {
                 id: test.id,
@@ -202,6 +232,16 @@ export const diagnosticsService = {
 
     achievementsService.checkAndAward(userId, { trigger: "test" }).catch(() => {});
 
+    // Fire-and-forget: generate the AI report in the background.
+    // Creating the pending row synchronously lets the psychologist UI poll
+    // right away even before the LLM response comes back.
+    aiReportService.ensurePending(sessionId).catch((e) => {
+      console.error("[diagnostics] failed to ensure AI report row", e);
+    });
+    void aiReportService.generateReport(sessionId).catch((e) => {
+      console.error("[diagnostics] AI report generation failed", e);
+    });
+
     return {
       sessionId: completed!.id,
       totalScore,
@@ -321,6 +361,86 @@ export const diagnosticsService = {
       .returning();
 
     return assignment[0];
+  },
+
+  async getAiReportForPsychologist(
+    psychologistId: string,
+    sessionId: string,
+  ) {
+    const access = await diagnosticsRepository.canPsychologistAccessSession(
+      psychologistId,
+      sessionId,
+    );
+    if (!access.found) throw new NotFoundError("Session not found");
+    if (!access.linked) {
+      throw new ForbiddenError("You are not linked to this student");
+    }
+    const existing = await aiReportService.findBySessionId(sessionId);
+    if (!existing) {
+      // Session exists but no report was ever generated — kick one off.
+      await aiReportService.ensurePending(sessionId);
+      void aiReportService.generateReport(sessionId).catch(() => {});
+      return { status: "pending" as const };
+    }
+    return existing;
+  },
+
+  async regenerateAiReport(psychologistId: string, sessionId: string) {
+    const access = await diagnosticsRepository.canPsychologistAccessSession(
+      psychologistId,
+      sessionId,
+    );
+    if (!access.found) throw new NotFoundError("Session not found");
+    if (!access.linked) {
+      throw new ForbiddenError("You are not linked to this student");
+    }
+    await aiReportService.resetToPending(sessionId);
+    void aiReportService.generateReport(sessionId).catch(() => {});
+    return { status: "pending" as const };
+  },
+
+  async getSessionAnswersForPsychologist(
+    psychologistId: string,
+    sessionId: string,
+  ) {
+    const access = await diagnosticsRepository.canPsychologistAccessSession(
+      psychologistId,
+      sessionId,
+    );
+    if (!access.found) throw new NotFoundError("Session not found");
+    if (!access.linked) {
+      throw new ForbiddenError("You are not linked to this student");
+    }
+    const session = await diagnosticsRepository.findSessionById(sessionId);
+    if (!session) throw new NotFoundError("Session not found");
+    const test = await diagnosticsRepository.findTestById(session.testId);
+    const answers = await diagnosticsRepository.findAnswersBySession(sessionId);
+
+    const questions = (test?.questions as Array<{
+      index?: number;
+      textRu?: string;
+      textKz?: string;
+      options?: Array<{ value: number; labelRu?: string; labelKz?: string }>;
+    }>) ?? [];
+
+    return {
+      sessionId,
+      testSlug: test?.slug ?? null,
+      testName: test?.nameRu ?? null,
+      items: answers.map((a) => {
+        const q = questions.find(
+          (x) => (x.index ?? questions.indexOf(x)) === a.questionIndex,
+        );
+        return {
+          questionIndex: a.questionIndex,
+          questionText: q?.textRu ?? null,
+          answer: a.answer,
+          answerLabel:
+            q?.options?.find((o) => o.value === a.answer)?.labelRu ?? null,
+          score: a.score,
+        };
+      }),
+    };
   },
 
   async getResultsForPsychologist(

--- a/packages/psychologist-app/src/api/diagnostics.ts
+++ b/packages/psychologist-app/src/api/diagnostics.ts
@@ -1,5 +1,10 @@
 import { apiFetch } from "./client.js";
-import type { Severity, PaginatedResponse } from "@tirek/shared";
+import type {
+  DiagnosticAiReport,
+  PaginatedResponse,
+  SessionAnswersResponse,
+  Severity,
+} from "@tirek/shared";
 
 export interface DiagnosticsFilters {
   testSlug?: string;
@@ -52,4 +57,27 @@ export function assignTest(data: AssignTestData) {
     method: "POST",
     body: JSON.stringify(data),
   });
+}
+
+/**
+ * Server returns the full report when ready, or a minimal { status: "pending" }
+ * stub (with HTTP 202) while the LLM is still generating.
+ */
+export function getReport(sessionId: string) {
+  return apiFetch<DiagnosticAiReport | { status: "pending" }>(
+    `/psychologist/diagnostics/sessions/${sessionId}/report`,
+  );
+}
+
+export function regenerateReport(sessionId: string) {
+  return apiFetch<{ status: "pending" }>(
+    `/psychologist/diagnostics/sessions/${sessionId}/report/regenerate`,
+    { method: "POST" },
+  );
+}
+
+export function getSessionAnswers(sessionId: string) {
+  return apiFetch<SessionAnswersResponse>(
+    `/psychologist/diagnostics/sessions/${sessionId}/answers`,
+  );
 }

--- a/packages/psychologist-app/src/components/diagnostics/AiReportCard.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/AiReportCard.tsx
@@ -1,0 +1,414 @@
+import { useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Bot,
+  CheckCircle2,
+  Info,
+  LineChart,
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+  Sparkles,
+  Stethoscope,
+  Users,
+  Wind,
+} from "lucide-react";
+import { clsx } from "clsx";
+import type {
+  AiReportRecommendationType,
+  DiagnosticAiReport,
+} from "@tirek/shared";
+import {
+  getReport,
+  getSessionAnswers,
+  regenerateReport,
+} from "../../api/diagnostics.js";
+
+interface AiReportCardProps {
+  sessionId: string;
+}
+
+const RISK_STYLES: Record<string, { bg: string; text: string; label: string }> = {
+  low: { bg: "bg-emerald-50", text: "text-emerald-700", label: "Низкий" },
+  moderate: { bg: "bg-amber-50", text: "text-amber-700", label: "Средний" },
+  high: { bg: "bg-red-50", text: "text-red-700", label: "Высокий" },
+};
+
+const RECOMMENDATION_META: Record<
+  AiReportRecommendationType,
+  { icon: typeof Stethoscope; label: string; bg: string; color: string }
+> = {
+  therapy: {
+    icon: Users,
+    label: "Индивидуальная беседа",
+    bg: "bg-blue-50",
+    color: "text-blue-700",
+  },
+  exercise: {
+    icon: Wind,
+    label: "Упражнение",
+    bg: "bg-teal-50",
+    color: "text-teal-700",
+  },
+  referral: {
+    icon: Stethoscope,
+    label: "Направление",
+    bg: "bg-purple-50",
+    color: "text-purple-700",
+  },
+  monitoring: {
+    icon: LineChart,
+    label: "Наблюдение",
+    bg: "bg-slate-50",
+    color: "text-slate-700",
+  },
+  conversation: {
+    icon: Users,
+    label: "Разговор",
+    bg: "bg-indigo-50",
+    color: "text-indigo-700",
+  },
+};
+
+function isReadyReport(
+  r: DiagnosticAiReport | { status: "pending" } | undefined,
+): r is DiagnosticAiReport {
+  return Boolean(r && "summary" in r && r.status === "ready");
+}
+
+function isErrorReport(
+  r: DiagnosticAiReport | { status: "pending" } | undefined,
+): r is DiagnosticAiReport {
+  return Boolean(r && "status" in r && r.status === "error");
+}
+
+export function AiReportCard({ sessionId }: AiReportCardProps) {
+  const queryClient = useQueryClient();
+
+  const { data: report, isLoading } = useQuery({
+    queryKey: ["diagnostics", "report", sessionId],
+    queryFn: () => getReport(sessionId),
+    // Poll while the report is still being generated.
+    refetchInterval: (q) => {
+      const d = q.state.data;
+      if (!d) return 3000;
+      if ("status" in d && d.status === "pending") return 3000;
+      return false;
+    },
+  });
+
+  const { data: answers } = useQuery({
+    queryKey: ["diagnostics", "answers", sessionId],
+    queryFn: () => getSessionAnswers(sessionId),
+    enabled: isReadyReport(report),
+  });
+
+  const regenerate = useMutation({
+    mutationFn: () => regenerateReport(sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["diagnostics", "report", sessionId],
+      });
+    },
+  });
+
+  const flaggedWithText = useMemo(() => {
+    if (!isReadyReport(report) || !report.flaggedItems || !answers) return [];
+    return report.flaggedItems.map((f) => {
+      const a = answers.items.find((i) => i.questionIndex === f.questionIndex);
+      return {
+        ...f,
+        questionText: a?.questionText ?? null,
+        answerLabel: a?.answerLabel ?? null,
+        answerValue: a?.answer ?? null,
+      };
+    });
+  }, [report, answers]);
+
+  if (isLoading || !report) {
+    return (
+      <div className="rounded-2xl border border-border-light bg-white p-5">
+        <SkeletonReport />
+      </div>
+    );
+  }
+
+  if (isErrorReport(report)) {
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50/50 p-5">
+        <div className="flex items-center gap-2 text-red-700">
+          <AlertCircle size={18} />
+          <p className="text-sm font-bold">Не удалось сгенерировать отчёт</p>
+        </div>
+        {report.errorMessage && (
+          <p className="mt-2 text-xs text-red-600">{report.errorMessage}</p>
+        )}
+        <button
+          type="button"
+          onClick={() => regenerate.mutate()}
+          disabled={regenerate.isPending}
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-bold text-white hover:bg-red-700 disabled:opacity-60"
+        >
+          {regenerate.isPending ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : (
+            <RefreshCw size={14} />
+          )}
+          Перегенерировать
+        </button>
+      </div>
+    );
+  }
+
+  if (!isReadyReport(report)) {
+    // pending
+    return (
+      <div className="rounded-2xl border border-border-light bg-white p-5">
+        <SkeletonReport />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-border-light bg-white p-5">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-violet-100 to-indigo-100">
+            <Bot size={18} className="text-indigo-600" />
+          </div>
+          <div>
+            <p className="text-xs font-bold uppercase tracking-wider text-indigo-700">
+              AI-анализ результата
+            </p>
+            {report.generatedAt && (
+              <p className="text-[11px] text-text-light">
+                Сформировано{" "}
+                {new Date(report.generatedAt).toLocaleString("ru-RU", {
+                  day: "numeric",
+                  month: "short",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </p>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => regenerate.mutate()}
+          disabled={regenerate.isPending}
+          className="inline-flex items-center gap-1 rounded-lg border border-border-light px-2 py-1 text-[11px] font-semibold text-text-light hover:bg-gray-50 disabled:opacity-60"
+          title="Перегенерировать"
+        >
+          {regenerate.isPending ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <RefreshCw size={12} />
+          )}
+          Обновить
+        </button>
+      </div>
+
+      {/* Summary */}
+      {report.summary && (
+        <p className="text-sm font-bold leading-snug text-text-main">
+          {report.summary}
+        </p>
+      )}
+
+      {/* Interpretation */}
+      {report.interpretation && (
+        <div>
+          <SectionTitle icon={Sparkles} label="Интерпретация" />
+          <p className="mt-1.5 whitespace-pre-line text-sm leading-relaxed text-text-main">
+            {report.interpretation}
+          </p>
+        </div>
+      )}
+
+      {/* Trend */}
+      {report.trend && (
+        <div className="rounded-xl border border-border-light bg-gray-50 p-3">
+          <div className="flex items-center gap-2">
+            <LineChart size={14} className="text-text-light" />
+            <p className="text-[11px] font-bold uppercase tracking-wider text-text-light">
+              Динамика
+            </p>
+          </div>
+          <p className="mt-1 text-xs text-text-main">{report.trend}</p>
+        </div>
+      )}
+
+      {/* Risk factors */}
+      {report.riskFactors && report.riskFactors.length > 0 && (
+        <div>
+          <SectionTitle icon={ShieldAlert} label="Факторы риска" />
+          <ul className="mt-2 space-y-2">
+            {report.riskFactors.map((rf, idx) => {
+              const meta = RISK_STYLES[rf.severity] ?? RISK_STYLES.moderate;
+              return (
+                <li
+                  key={idx}
+                  className="flex gap-3 rounded-xl border border-border-light p-3"
+                >
+                  <span
+                    className={clsx(
+                      "mt-0.5 inline-flex h-fit items-center whitespace-nowrap rounded-full px-2 py-0.5 text-[10px] font-bold",
+                      meta.bg,
+                      meta.text,
+                    )}
+                  >
+                    {meta.label}
+                  </span>
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold text-text-main">
+                      {rf.factor}
+                    </p>
+                    {rf.evidence && (
+                      <p className="mt-0.5 text-xs text-text-light">
+                        {rf.evidence}
+                      </p>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {/* Recommendations */}
+      {report.recommendations && report.recommendations.length > 0 && (
+        <div>
+          <SectionTitle icon={CheckCircle2} label="Рекомендации" />
+          <ul className="mt-2 space-y-2">
+            {report.recommendations.map((r, idx) => {
+              const meta =
+                RECOMMENDATION_META[r.type] ?? RECOMMENDATION_META.monitoring;
+              const Icon = meta.icon;
+              return (
+                <li
+                  key={idx}
+                  className="flex gap-3 rounded-xl border border-border-light p-3"
+                >
+                  <div
+                    className={clsx(
+                      "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
+                      meta.bg,
+                    )}
+                  >
+                    <Icon size={16} className={meta.color} />
+                  </div>
+                  <div className="flex-1">
+                    <p
+                      className={clsx(
+                        "text-[10px] font-bold uppercase tracking-wider",
+                        meta.color,
+                      )}
+                    >
+                      {meta.label}
+                    </p>
+                    <p className="mt-0.5 text-sm text-text-main">{r.text}</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {/* Flagged items */}
+      {flaggedWithText.length > 0 && (
+        <details className="rounded-xl border border-amber-200 bg-amber-50/50 p-3">
+          <summary className="flex cursor-pointer items-center gap-2 text-sm font-bold text-amber-800">
+            <AlertTriangle size={14} />
+            Тревожные ответы ({flaggedWithText.length})
+          </summary>
+          <ul className="mt-3 space-y-2">
+            {flaggedWithText.map((f, idx) => (
+              <li
+                key={idx}
+                className="rounded-lg border border-amber-100 bg-white p-2.5"
+              >
+                {f.questionText && (
+                  <p className="text-xs font-semibold text-text-main">
+                    {f.questionText}
+                  </p>
+                )}
+                {(f.answerLabel || f.answerValue !== null) && (
+                  <p className="mt-1 text-xs text-text-light">
+                    Ответ:{" "}
+                    <span className="font-bold text-amber-700">
+                      {f.answerLabel ?? `значение ${f.answerValue}`}
+                    </span>
+                  </p>
+                )}
+                {f.reason && (
+                  <p className="mt-1 text-[11px] italic text-text-light">
+                    {f.reason}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      {/* Disclaimer */}
+      <div className="flex items-start gap-2 rounded-lg bg-gray-50 p-2.5 text-[11px] text-text-light">
+        <Info size={12} className="mt-0.5 shrink-0" />
+        <p>
+          Отчёт сформирован ИИ на основе ответов ученика и требует
+          профессиональной оценки специалистом.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SectionTitle({
+  icon: Icon,
+  label,
+}: {
+  icon: typeof Stethoscope;
+  label: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Icon size={13} className="text-text-light" />
+      <p className="text-[11px] font-bold uppercase tracking-wider text-text-light">
+        {label}
+      </p>
+    </div>
+  );
+}
+
+function SkeletonReport() {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-violet-100 to-indigo-100">
+          <Loader2 size={18} className="animate-spin text-indigo-600" />
+        </div>
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-indigo-700">
+            AI-анализ результата
+          </p>
+          <p className="text-[11px] text-text-light">Генерируется…</p>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <div className="h-3 w-3/4 animate-pulse rounded bg-gray-200" />
+        <div className="h-3 w-full animate-pulse rounded bg-gray-200" />
+        <div className="h-3 w-5/6 animate-pulse rounded bg-gray-200" />
+      </div>
+      <div className="space-y-2 pt-2">
+        <div className="h-10 animate-pulse rounded-xl bg-gray-100" />
+        <div className="h-10 animate-pulse rounded-xl bg-gray-100" />
+      </div>
+    </div>
+  );
+}

--- a/packages/psychologist-app/src/components/student/StudentAssessmentsTab.tsx
+++ b/packages/psychologist-app/src/components/student/StudentAssessmentsTab.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { Loader2, FileText, Brain, Award, Lock } from "lucide-react";
+import { ChevronDown, ChevronUp, Loader2, FileText, Brain, Award, Lock } from "lucide-react";
 import { clsx } from "clsx";
 import { useT } from "../../hooks/useLanguage.js";
 import { useLanguage } from "../../hooks/useLanguage.js";
 import { SeverityBadge } from "../ui/SeverityBadge.js";
+import { AiReportCard } from "../diagnostics/AiReportCard.js";
 import type { DiagnosticSession, CbtEntry, ThoughtDiaryData, UserAchievementItem } from "@tirek/shared";
 
 type SubTab = "tests" | "cbt" | "achievements";
@@ -27,6 +28,7 @@ export function StudentAssessmentsTab({
   const { language } = useLanguage();
   const d = t.psychologist.studentDetail;
   const [subTab, setSubTab] = useState<SubTab>("tests");
+  const [expandedSessionId, setExpandedSessionId] = useState<string | null>(null);
 
   const subTabs: { key: SubTab; label: string }[] = [
     { key: "tests", label: d.testsTab },
@@ -64,33 +66,58 @@ export function StudentAssessmentsTab({
             </div>
           ) : (
             <div className="space-y-2">
-              {testResults.map((result) => (
-                <div
-                  key={result.id}
-                  className="bg-surface rounded-xl border border-border shadow-sm p-4"
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="min-w-0">
-                      <p className="text-sm font-semibold text-text-main">
-                        {result.testName ?? result.testSlug ?? result.testId}
-                      </p>
-                      <p className="text-xs text-text-light mt-0.5">
-                        {result.completedAt
-                          ? new Date(result.completedAt).toLocaleDateString()
-                          : "—"}
-                      </p>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      {result.totalScore != null && (
-                        <span className="text-sm font-bold text-text-main">
-                          {result.totalScore}/{result.maxScore ?? "?"}
-                        </span>
-                      )}
-                      {result.severity && <SeverityBadge severity={result.severity} />}
-                    </div>
+              {testResults.map((result) => {
+                const isExpanded = expandedSessionId === result.id;
+                const hasReport = Boolean(result.completedAt);
+                return (
+                  <div
+                    key={result.id}
+                    className="bg-surface rounded-xl border border-border shadow-sm"
+                  >
+                    <button
+                      type="button"
+                      onClick={() =>
+                        hasReport &&
+                        setExpandedSessionId(isExpanded ? null : result.id)
+                      }
+                      disabled={!hasReport}
+                      className="w-full text-left p-4 flex items-start justify-between gap-3 disabled:cursor-default"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-text-main">
+                          {result.testName ?? result.testSlug ?? result.testId}
+                        </p>
+                        <p className="text-xs text-text-light mt-0.5">
+                          {result.completedAt
+                            ? new Date(result.completedAt).toLocaleDateString()
+                            : "—"}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        {result.totalScore != null && (
+                          <span className="text-sm font-bold text-text-main">
+                            {result.totalScore}/{result.maxScore ?? "?"}
+                          </span>
+                        )}
+                        {result.severity && (
+                          <SeverityBadge severity={result.severity} />
+                        )}
+                        {hasReport &&
+                          (isExpanded ? (
+                            <ChevronUp size={16} className="text-text-light" />
+                          ) : (
+                            <ChevronDown size={16} className="text-text-light" />
+                          ))}
+                      </div>
+                    </button>
+                    {isExpanded && hasReport && (
+                      <div className="border-t border-border p-4 bg-surface-secondary/30">
+                        <AiReportCard sessionId={result.id} />
+                      </div>
+                    )}
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           )}
         </div>

--- a/packages/psychologist-app/src/pages/DiagnosticsPage.tsx
+++ b/packages/psychologist-app/src/pages/DiagnosticsPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { useT } from "../hooks/useLanguage.js";
 import { getResults } from "../api/diagnostics.js";
 import { SeverityBadge } from "../components/ui/SeverityBadge.js";
+import { AiReportCard } from "../components/diagnostics/AiReportCard.js";
 import {
   ClipboardPlus,
   ClipboardList,
@@ -11,6 +12,8 @@ import {
   Calendar,
   Download,
   ChevronRight,
+  Sparkles,
+  X,
 } from "lucide-react";
 import { exportApi } from "../api/export.js";
 import { ErrorState } from "../components/ui/ErrorState.js";
@@ -24,6 +27,11 @@ export function DiagnosticsPage() {
   const [grade, setGrade] = useState("");
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
+  const [reportSession, setReportSession] = useState<{
+    sessionId: string;
+    studentName?: string;
+    testName?: string | null;
+  } | null>(null);
 
   const { data: results, isLoading, isError, refetch } = useQuery({
     queryKey: [
@@ -150,53 +158,111 @@ export function DiagnosticsPage() {
       ) : results && results.data.length > 0 ? (
         <div className="space-y-2">
           {results.data.map((row) => (
-            <button
+            <div
               key={row.sessionId}
-              onClick={() => navigate(`/students/${row.studentId}`)}
-              className="btn-press w-full flex items-center gap-3 p-3 rounded-xl bg-surface border border-border shadow-sm transition-all hover:shadow-md text-left"
+              className="w-full flex items-center gap-3 p-3 rounded-xl bg-surface border border-border shadow-sm transition-all hover:shadow-md"
             >
-              <div className="w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold shrink-0">
-                {(row.studentName ?? "S").charAt(0).toUpperCase()}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold text-text-main truncate">
-                    {row.studentName ?? "Student"}
-                  </span>
-                  {row.studentGrade && (
-                    <span className="text-xs text-text-light shrink-0">
-                      {row.studentGrade}{row.studentClass ?? ""}
+              <button
+                type="button"
+                onClick={() => navigate(`/students/${row.studentId}`)}
+                className="btn-press flex flex-1 min-w-0 items-center gap-3 text-left"
+              >
+                <div className="w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold shrink-0">
+                  {(row.studentName ?? "S").charAt(0).toUpperCase()}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold text-text-main truncate">
+                      {row.studentName ?? "Student"}
+                    </span>
+                    {row.studentGrade && (
+                      <span className="text-xs text-text-light shrink-0">
+                        {row.studentGrade}
+                        {row.studentClass ?? ""}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-0.5">
+                    <span className="text-xs text-text-light truncate">
+                      {row.testName ?? row.testSlug ?? row.testId}
+                    </span>
+                    <span className="text-xs text-text-light">&middot;</span>
+                    <span className="text-xs text-text-light">
+                      {row.completedAt
+                        ? new Date(row.completedAt).toLocaleDateString()
+                        : "\u2014"}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex flex-col items-end gap-1 shrink-0">
+                  {row.totalScore != null && (
+                    <span className="text-xs font-bold text-text-main">
+                      {row.totalScore}/{row.maxScore ?? "?"}
                     </span>
                   )}
+                  {row.severity && <SeverityBadge severity={row.severity} />}
                 </div>
-                <div className="flex items-center gap-2 mt-0.5">
-                  <span className="text-xs text-text-light truncate">
-                    {row.testName ?? row.testSlug ?? row.testId}
-                  </span>
-                  <span className="text-xs text-text-light">&middot;</span>
-                  <span className="text-xs text-text-light">
-                    {row.completedAt
-                      ? new Date(row.completedAt).toLocaleDateString()
-                      : "\u2014"}
-                  </span>
-                </div>
-              </div>
-              <div className="flex flex-col items-end gap-1 shrink-0">
-                {row.totalScore != null && (
-                  <span className="text-xs font-bold text-text-main">
-                    {row.totalScore}/{row.maxScore ?? "?"}
-                  </span>
-                )}
-                {row.severity && <SeverityBadge severity={row.severity} />}
-              </div>
-              <ChevronRight size={14} className="text-text-light/40 shrink-0" />
-            </button>
+                <ChevronRight size={14} className="text-text-light/40 shrink-0" />
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setReportSession({
+                    sessionId: row.sessionId,
+                    studentName: row.studentName,
+                    testName: row.testName,
+                  })
+                }
+                className="shrink-0 inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-indigo-50 px-2 py-1.5 text-[11px] font-bold text-indigo-700 hover:bg-indigo-100"
+                title="AI-анализ"
+              >
+                <Sparkles size={12} />
+                AI-анализ
+              </button>
+            </div>
           ))}
         </div>
       ) : (
         <div className="flex flex-col items-center py-12">
           <ClipboardList size={36} className="text-text-light mb-2" />
           <p className="text-sm text-text-light">{t.common.noData}</p>
+        </div>
+      )}
+
+      {/* AI-report drawer/modal */}
+      {reportSession && (
+        <div
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40"
+          onClick={() => setReportSession(null)}
+        >
+          <div
+            className="bg-surface w-full sm:max-w-2xl max-h-[90vh] overflow-y-auto rounded-t-2xl sm:rounded-2xl shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="sticky top-0 flex items-center justify-between gap-3 border-b border-border bg-surface px-5 py-3">
+              <div className="min-w-0">
+                <p className="text-xs font-bold uppercase tracking-wider text-indigo-700">
+                  AI-анализ
+                </p>
+                <p className="truncate text-sm font-semibold text-text-main">
+                  {reportSession.studentName ?? "Ученик"}
+                  {reportSession.testName
+                    ? ` · ${reportSession.testName}`
+                    : ""}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setReportSession(null)}
+                className="flex h-8 w-8 items-center justify-center rounded-lg text-text-light hover:bg-surface-hover"
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <div className="p-4">
+              <AiReportCard sessionId={reportSession.sessionId} />
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -86,6 +86,83 @@ export interface DiagnosticSession {
   severity: Severity | null;
 }
 
+export type AssignmentStatus = "not_started" | "in_progress" | "completed";
+
+export interface AssignedTest {
+  assignmentId: string;
+  testId: string;
+  dueDate: string | null;
+  status: AssignmentStatus;
+  completedSessionId: string | null;
+  overdue: boolean;
+  assignedAt: string;
+  test: {
+    id: string;
+    slug: string;
+    nameRu: string;
+    nameKz: string | null;
+    description: string | null;
+    questionCount: number;
+  } | null;
+}
+
+export type AiReportStatus = "pending" | "ready" | "error";
+
+export interface AiReportRiskFactor {
+  factor: string;
+  severity: "low" | "moderate" | "high";
+  evidence?: string;
+}
+
+export type AiReportRecommendationType =
+  | "therapy"
+  | "exercise"
+  | "referral"
+  | "monitoring"
+  | "conversation";
+
+export interface AiReportRecommendation {
+  type: AiReportRecommendationType;
+  text: string;
+}
+
+export interface AiReportFlaggedItem {
+  questionIndex: number;
+  reason: string;
+}
+
+export interface DiagnosticAiReport {
+  sessionId: string;
+  status: AiReportStatus;
+  model: string | null;
+  summary: string | null;
+  interpretation: string | null;
+  riskFactors: AiReportRiskFactor[] | null;
+  recommendations: AiReportRecommendation[] | null;
+  trend: string | null;
+  flaggedItems: AiReportFlaggedItem[] | null;
+  tokensUsed: number | null;
+  errorMessage: string | null;
+  generatedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SessionAnswerItem {
+  questionIndex: number;
+  questionText: string | null;
+  answer: number;
+  answerLabel: string | null;
+  score: number | null;
+}
+
+export interface SessionAnswersResponse {
+  sessionId: string;
+  testSlug: string | null;
+  testName: string | null;
+  items: SessionAnswerItem[];
+}
+
 export interface TestResultStudent {
   severity: Severity;
   friendlyMessage: string;

--- a/packages/student-app/src/api/tests.ts
+++ b/packages/student-app/src/api/tests.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "./client.js";
-import type { DiagnosticTest, DiagnosticSession, Severity, PaginatedResponse } from "@tirek/shared";
+import type { AssignedTest, DiagnosticTest, DiagnosticSession, Severity, PaginatedResponse } from "@tirek/shared";
 
 export interface SessionResult {
   sessionId: string;
@@ -15,7 +15,7 @@ export interface SessionResult {
 export const testsApi = {
   list: () => apiFetch<DiagnosticTest[]>("/student/tests/"),
 
-  assigned: () => apiFetch<DiagnosticTest[]>("/student/tests/assigned"),
+  assigned: () => apiFetch<AssignedTest[]>("/student/tests/assigned"),
 
   start: (testId: string) =>
     apiFetch<DiagnosticSession>(`/student/tests/${testId}/start`, { method: "POST" }),

--- a/packages/student-app/src/pages/DashboardPage.tsx
+++ b/packages/student-app/src/pages/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { plantApi } from "../api/plant.js";
 import { exercisesApi } from "../api/exercises.js";
 import { appointmentsApi } from "../api/appointments.js";
 import { achievementsApi } from "../api/achievements.js";
+import { testsApi } from "../api/tests.js";
 import { moodLevels } from "@tirek/shared";
 import { AppLayout } from "../components/ui/AppLayout.js";
 import { ErrorState } from "../components/ui/ErrorState.js";
@@ -64,15 +65,24 @@ export function DashboardPage() {
     queryFn: achievementsApi.getSummary,
   });
 
+  const { data: assignedTests = [] } = useQuery({
+    queryKey: ["tests", "assigned"],
+    queryFn: () => testsApi.assigned(),
+  });
+
+  const pendingTestsCount = assignedTests.filter(
+    (a) => a.status !== "completed",
+  ).length;
+
   const quickLinks = [
-    { to: "/chat", icon: MessageCircle, label: t.nav.chat, iconBg: "bg-teal-100", color: "text-teal-700" },
-    { to: "/tests", icon: ClipboardList, label: t.nav.tests, iconBg: "bg-emerald-100", color: "text-emerald-700" },
-    { to: "/exercises", icon: Wind, label: t.nav.exercises, iconBg: "bg-sky-100", color: "text-sky-700" },
-    { to: "/journal", icon: BookOpen, label: t.nav.journal, iconBg: "bg-amber-100", color: "text-amber-700" },
-    { to: "/messages", icon: Mail, label: t.directChat.title, iconBg: "bg-green-100", color: "text-green-700" },
-    { to: "/mood/calendar", icon: CalendarDays, label: t.mood.calendar, iconBg: "bg-blue-100", color: "text-blue-700" },
-    { to: "/appointments", icon: Calendar, label: t.nav.appointments, iconBg: "bg-violet-100", color: "text-violet-700" },
-    { to: "/achievements", icon: Award, label: t.achievements.title, iconBg: "bg-yellow-100", color: "text-yellow-700" },
+    { to: "/chat", icon: MessageCircle, label: t.nav.chat, iconBg: "bg-teal-100", color: "text-teal-700", badge: 0 },
+    { to: "/tests", icon: ClipboardList, label: t.nav.tests, iconBg: "bg-emerald-100", color: "text-emerald-700", badge: pendingTestsCount },
+    { to: "/exercises", icon: Wind, label: t.nav.exercises, iconBg: "bg-sky-100", color: "text-sky-700", badge: 0 },
+    { to: "/journal", icon: BookOpen, label: t.nav.journal, iconBg: "bg-amber-100", color: "text-amber-700", badge: 0 },
+    { to: "/messages", icon: Mail, label: t.directChat.title, iconBg: "bg-green-100", color: "text-green-700", badge: 0 },
+    { to: "/mood/calendar", icon: CalendarDays, label: t.mood.calendar, iconBg: "bg-blue-100", color: "text-blue-700", badge: 0 },
+    { to: "/appointments", icon: Calendar, label: t.nav.appointments, iconBg: "bg-violet-100", color: "text-violet-700", badge: 0 },
+    { to: "/achievements", icon: Award, label: t.achievements.title, iconBg: "bg-yellow-100", color: "text-yellow-700", badge: 0 },
   ];
 
   const avatarEmoji = user?.avatarId ? (AVATAR_MAP[user.avatarId] ?? "\u{1F60A}") : "\u{1F60A}";
@@ -291,10 +301,15 @@ export function DashboardPage() {
               <Link
                 key={item.to}
                 to={item.to}
-                className="btn-press flex flex-col items-center gap-2.5 rounded-2xl bg-white p-5 shadow-sm border border-border-light transition-all hover:shadow-md"
+                className="btn-press relative flex flex-col items-center gap-2.5 rounded-2xl bg-white p-5 shadow-sm border border-border-light transition-all hover:shadow-md"
               >
-                <div className={`flex h-11 w-11 items-center justify-center rounded-xl ${item.iconBg}`}>
+                <div className={`relative flex h-11 w-11 items-center justify-center rounded-xl ${item.iconBg}`}>
                   <item.icon size={22} className={item.color} />
+                  {item.badge > 0 && (
+                    <span className="absolute -right-1.5 -top-1.5 flex min-w-[18px] h-[18px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white shadow-sm">
+                      {item.badge > 9 ? "9+" : item.badge}
+                    </span>
+                  )}
                 </div>
                 <span className="text-xs font-bold text-text-main">{item.label}</span>
               </Link>

--- a/packages/student-app/src/pages/TestsListPage.tsx
+++ b/packages/student-app/src/pages/TestsListPage.tsx
@@ -1,9 +1,22 @@
+import { useState } from "react";
 import { useNavigate } from "react-router";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Sparkles,
+} from "lucide-react";
 import { useT } from "../hooks/useLanguage.js";
 import { useLanguage } from "../hooks/useLanguage.js";
 import { testDefinitions } from "@tirek/shared";
+import type { AssignedTest } from "@tirek/shared";
 import { AppLayout } from "../components/ui/AppLayout.js";
+import { testsApi } from "../api/tests.js";
 
 const TEST_ICONS: Record<string, { iconBg: string; emoji: string }> = {
   "phq-a": { iconBg: "bg-blue-100", emoji: "\u{1F49C}" },
@@ -24,12 +37,78 @@ const TEST_ICONS: Record<string, { iconBg: string; emoji: string }> = {
   "olweus-bullying": { iconBg: "bg-amber-100", emoji: "\u{1F6A8}" },
 };
 
+function formatDueDate(iso: string | null): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "long",
+  });
+}
+
+function StatusBadge({ assignment }: { assignment: AssignedTest }) {
+  if (assignment.status === "completed") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-bold text-emerald-700">
+        <CheckCircle2 size={10} /> Пройдено
+      </span>
+    );
+  }
+  if (assignment.overdue) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2 py-0.5 text-[10px] font-bold text-red-700">
+        <AlertTriangle size={10} /> Просрочено
+      </span>
+    );
+  }
+  if (assignment.status === "in_progress") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-bold text-amber-700">
+        <Clock size={10} /> Не завершено
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-bold text-blue-700">
+      <Sparkles size={10} /> Новое
+    </span>
+  );
+}
+
 export function TestsListPage() {
   const t = useT();
   const { language } = useLanguage();
   const navigate = useNavigate();
+  const [showOthers, setShowOthers] = useState(false);
 
-  const tests = Object.values(testDefinitions);
+  const { data: assignments = [] } = useQuery({
+    queryKey: ["tests", "assigned"],
+    queryFn: () => testsApi.assigned(),
+  });
+
+  const allTests = Object.values(testDefinitions);
+
+  // De-dupe "Other tests" by removing those already assigned
+  const assignedSlugs = new Set(
+    assignments.map((a) => a.test?.slug).filter((s): s is string => Boolean(s)),
+  );
+  const otherTests = allTests.filter((t) => !assignedSlugs.has(t.slug));
+
+  const handleAssignmentClick = (a: AssignedTest) => {
+    if (!a.test) return;
+    if (a.status === "completed" && a.completedSessionId) {
+      navigate(`/tests/results/${a.completedSessionId}`);
+    } else {
+      navigate(`/tests/${a.test.slug}`);
+    }
+  };
+
+  const assignmentActionLabel = (a: AssignedTest) => {
+    if (a.status === "completed") return "Посмотреть результат";
+    if (a.status === "in_progress") return "Продолжить";
+    return "Пройти";
+  };
 
   return (
     <AppLayout>
@@ -45,34 +124,130 @@ export function TestsListPage() {
           <h1 className="text-xl font-bold text-text-main">{t.tests.title}</h1>
         </div>
 
-        {/* Test cards */}
-        <div className="mt-6 space-y-3 stagger-children">
-          {tests.map((test) => {
-            const meta = TEST_ICONS[test.slug] ?? { iconBg: "bg-gray-100", emoji: "\u{1F4CB}" };
-            const name = language === "kz" ? test.nameKz : test.nameRu;
-            const desc = language === "kz" ? test.descriptionKz : test.descriptionRu;
+        {/* Assigned section */}
+        <section className="mt-6">
+          <h2 className="text-sm font-bold text-text-main">
+            Назначенные психологом
+          </h2>
+          {assignments.length === 0 ? (
+            <div className="mt-3 rounded-2xl border border-dashed border-border-light bg-white px-4 py-6 text-center">
+              <p className="text-xs text-text-light">
+                Пока психолог не назначил вам тестов. Можно пройти любой из
+                раздела ниже.
+              </p>
+            </div>
+          ) : (
+            <div className="mt-3 space-y-3 stagger-children">
+              {assignments.map((a) => {
+                if (!a.test) return null;
+                const meta =
+                  TEST_ICONS[a.test.slug] ??
+                  { iconBg: "bg-gray-100", emoji: "\u{1F4CB}" };
+                const name =
+                  language === "kz" ? a.test.nameKz ?? a.test.nameRu : a.test.nameRu;
+                const due = formatDueDate(a.dueDate);
+                const borderClass = a.overdue
+                  ? "border-red-200"
+                  : a.status === "completed"
+                    ? "border-emerald-200"
+                    : "border-border-light";
+                return (
+                  <button
+                    key={a.assignmentId}
+                    onClick={() => handleAssignmentClick(a)}
+                    className={`btn-press flex w-full items-start gap-4 rounded-2xl bg-white border ${borderClass} p-5 shadow-sm transition-all hover:shadow-md`}
+                  >
+                    <div
+                      className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${meta.iconBg}`}
+                    >
+                      <span className="text-2xl">{meta.emoji}</span>
+                    </div>
+                    <div className="flex-1 text-left">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-bold text-text-main">{name}</p>
+                        <StatusBadge assignment={a} />
+                      </div>
+                      <p className="mt-0.5 text-xs text-text-light line-clamp-2">
+                        {a.test.description}
+                      </p>
+                      <div className="mt-1.5 flex items-center gap-3 text-[10px] font-bold">
+                        {due && (
+                          <span
+                            className={
+                              a.overdue ? "text-red-600" : "text-text-light"
+                            }
+                          >
+                            Срок: {due}
+                          </span>
+                        )}
+                        <span className="text-primary-dark">
+                          {assignmentActionLabel(a)} →
+                        </span>
+                      </div>
+                    </div>
+                    <ArrowRight size={18} className="text-text-light mt-1" />
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </section>
 
-            return (
-              <button
-                key={test.slug}
-                onClick={() => navigate(`/tests/${test.slug}`)}
-                className="btn-press flex w-full items-center gap-4 rounded-2xl bg-white border border-border-light p-5 shadow-sm transition-all hover:shadow-md"
-              >
-                <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${meta.iconBg}`}>
-                  <span className="text-2xl">{meta.emoji}</span>
-                </div>
-                <div className="flex-1 text-left">
-                  <p className="text-sm font-bold text-text-main">{name}</p>
-                  <p className="mt-0.5 text-xs text-text-light line-clamp-2">{desc}</p>
-                  <p className="mt-1.5 text-[10px] font-bold text-primary-dark">
-                    {test.questions.length} {t.tests.question.toLowerCase()}
-                  </p>
-                </div>
-                <ArrowRight size={18} className="text-text-light" />
-              </button>
-            );
-          })}
-        </div>
+        {/* Other tests (collapsible) */}
+        <section className="mt-8">
+          <button
+            onClick={() => setShowOthers((v) => !v)}
+            className="flex w-full items-center justify-between rounded-xl bg-white border border-border-light px-4 py-3 shadow-sm"
+          >
+            <div className="text-left">
+              <p className="text-sm font-bold text-text-main">Другие тесты</p>
+              <p className="text-[11px] text-text-light">
+                Можно пройти самостоятельно · {otherTests.length}
+              </p>
+            </div>
+            {showOthers ? (
+              <ChevronUp size={18} className="text-text-light" />
+            ) : (
+              <ChevronDown size={18} className="text-text-light" />
+            )}
+          </button>
+
+          {showOthers && (
+            <div className="mt-3 space-y-3 stagger-children">
+              {otherTests.map((test) => {
+                const meta =
+                  TEST_ICONS[test.slug] ??
+                  { iconBg: "bg-gray-100", emoji: "\u{1F4CB}" };
+                const name = language === "kz" ? test.nameKz : test.nameRu;
+                const desc =
+                  language === "kz" ? test.descriptionKz : test.descriptionRu;
+                return (
+                  <button
+                    key={test.slug}
+                    onClick={() => navigate(`/tests/${test.slug}`)}
+                    className="btn-press flex w-full items-center gap-4 rounded-2xl bg-white border border-border-light p-5 shadow-sm transition-all hover:shadow-md"
+                  >
+                    <div
+                      className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${meta.iconBg}`}
+                    >
+                      <span className="text-2xl">{meta.emoji}</span>
+                    </div>
+                    <div className="flex-1 text-left">
+                      <p className="text-sm font-bold text-text-main">{name}</p>
+                      <p className="mt-0.5 text-xs text-text-light line-clamp-2">
+                        {desc}
+                      </p>
+                      <p className="mt-1.5 text-[10px] font-bold text-primary-dark">
+                        {test.questions.length} {t.tests.question.toLowerCase()}
+                      </p>
+                    </div>
+                    <ArrowRight size={18} className="text-text-light" />
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </section>
       </div>
     </AppLayout>
   );


### PR DESCRIPTION
## Зачем

Сейчас ученик видит все тесты одним списком и не понимает, что ему назначил психолог. А психолог после прохождения теста получает только скор + бейдж тяжести, без интерпретации и рекомендаций.

## Что внутри

**Student web**
- `TestsListPage`: сверху секция «Назначенные психологом» со статусом (`Новое` / `Не завершено` / `Просрочено` / `Пройдено`) и дедлайном; ниже сворачиваемый блок «Другие тесты» для самостоятельной диагностики
- `DashboardPage`: красный счётчик непройденных назначений на плитке Tests

**Psychologist web**
- Новый `AiReportCard`: сводка, клиническая интерпретация, динамика vs прошлых попыток, факторы риска, рекомендации (с типами: беседа/упражнение/направление/наблюдение), тревожные ответы с текстом вопроса, дисклеймер. Скелетон с полингом раз в 3 сек пока отчёт генерится; кнопка «Перегенерировать» при ошибке.
- Встроено в `StudentAssessmentsTab` (раскрывающаяся запись по каждому тесту) и в `DiagnosticsPage` (модалка по кнопке «AI-анализ» рядом с каждой строкой результата)

**Backend**
- Новая таблица `diagnostic_ai_reports` + миграция `0003_faulty_captain_stacy.sql`
- `ai-report.service.ts`: генерация структурированного JSON-отчёта через OpenAI `gpt-4.1-mini`, ответ в `response_format: json_object`, температура 0.3. История прошлых попыток теста подтягивается для поля `trend`.
- `completeSession` fire-and-forget запускает генерацию — ученик получает ответ мгновенно
- Новые эндпоинты (с проверкой привязки ученика к психологу через `studentPsychologist`):
  - `GET /psychologist/diagnostics/sessions/:id/report` (202 пока `pending`)
  - `POST /psychologist/diagnostics/sessions/:id/report/regenerate`
  - `GET /psychologist/diagnostics/sessions/:id/answers`
- `getAssignedTests` теперь возвращает `status`, `completedSessionId`, `overdue`, `assignedAt`

AI-отчёт **не** виден ученику — он продолжает видеть простой экран результата, как было.

## Test plan

- [ ] Применить миграцию (Railway сделает автоматически через `migrate.ts` в CMD)
- [ ] Проверить, что `OPENAI_API_KEY` задан в env
- [ ] Психолог → `/diagnostics/assign`: назначить PHQ-A ученику с дедлайном
- [ ] Ученик → на дашборде бейдж «1» на плитке Tests
- [ ] Ученик → `/tests`: сверху назначенный тест со сроком, ниже сворачиваемый блок «Другие тесты»
- [ ] Ученик проходит тест → на `/tests` карточка становится «Пройдено», бейдж исчезает
- [ ] Психолог → карточка ученика → Assessments → Tests → раскрыть: сначала скелетон «Генерируется…», затем полный AI-отчёт
- [ ] Психолог → `/diagnostics` → кнопка «AI-анализ» у строки → модалка с тем же отчётом
- [ ] `GET /psychologist/diagnostics/sessions/:id/report` для сессии чужого ученика → 403

https://claude.ai/code/session_01Ejo4rMKZQLdWM3n2DQ7jj9