### PR TITLE
DS · Components pack: Typography + Card + Pill + Input + Sheet (#52)

### DIFF
--- a/packages/psychologist-mobapp/app/(auth)/login.tsx
+++ b/packages/psychologist-mobapp/app/(auth)/login.tsx
@@ -11,7 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation } from "@tanstack/react-query";
-import { Text, Input, Button } from "../../components/ui";
+import { Text, Input, Button, Sheet, Body } from "../../components/ui";
 import { colors as ds, radius, spacing } from "@tirek/shared/design-system";
 import { useT, useLanguage } from "../../lib/hooks/useLanguage";
 import { authApi } from "../../lib/api/auth";
@@ -90,75 +90,78 @@ export default function LoginScreen() {
 
       {/* Sheet */}
       <KeyboardAvoidingView
-        style={styles.sheetWrap}
+        style={styles.kavWrap}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <ScrollView
-          style={styles.sheet}
-          contentContainerStyle={styles.sheetContent}
-          keyboardShouldPersistTaps="handled"
-        >
-          <View style={styles.form}>
-            <Input
-              icon="mail-outline"
-              placeholder={t.auth.email}
-              value={email}
-              onChangeText={setEmail}
-              keyboardType="email-address"
-              autoCapitalize="none"
-              autoComplete="email"
-            />
-
-            <View style={styles.passwordWrap}>
+        <Sheet variant="over-hero" overlap={SHEET_OVERLAP}>
+          <ScrollView
+            contentContainerStyle={styles.sheetContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.form}>
               <Input
-                icon="lock-closed-outline"
-                placeholder={t.auth.password}
-                value={password}
-                onChangeText={setPassword}
-                secureTextEntry={!showPassword}
+                icon="mail-outline"
+                placeholder={t.auth.email}
+                value={email}
+                onChangeText={setEmail}
+                keyboardType="email-address"
                 autoCapitalize="none"
+                autoComplete="email"
+                error={hasError}
               />
-              <Pressable
-                onPress={() => setShowPassword(!showPassword)}
-                style={styles.eyeBtn}
-                hitSlop={8}
-              >
-                <Ionicons
-                  name={showPassword ? "eye-off-outline" : "eye-outline"}
-                  size={20}
-                  color={c.textLight}
+
+              <View style={styles.passwordWrap}>
+                <Input
+                  icon="lock-closed-outline"
+                  placeholder={t.auth.password}
+                  value={password}
+                  onChangeText={setPassword}
+                  secureTextEntry={!showPassword}
+                  autoCapitalize="none"
+                  error={hasError}
                 />
-              </Pressable>
-            </View>
-
-            <Text style={styles.forgot}>{t.auth.forgotPassword}</Text>
-
-            {hasError && (
-              <View style={styles.errorBox}>
-                <Text style={styles.errorText}>
-                  {t.auth.invalidCredentials}
-                </Text>
+                <Pressable
+                  onPress={() => setShowPassword(!showPassword)}
+                  style={styles.eyeBtn}
+                  hitSlop={8}
+                >
+                  <Ionicons
+                    name={showPassword ? "eye-off-outline" : "eye-outline"}
+                    size={20}
+                    color={c.textLight}
+                  />
+                </Pressable>
               </View>
-            )}
 
-            <Button
-              title={t.auth.login}
-              onPress={() => loginMutation.mutate()}
-              loading={loginMutation.isPending}
-              disabled={!email.trim() || !password.trim()}
-              size="lg"
-            />
+              <Text style={styles.forgot}>{t.auth.forgotPassword}</Text>
 
-            <View style={styles.linkRow}>
-              <Text variant="small" style={{ color: c.textLight }}>
-                {t.auth.noAccount}{" "}
-              </Text>
-              <Pressable onPress={() => router.push("/(auth)/register")}>
-                <Text style={styles.linkText}>{t.auth.register}</Text>
-              </Pressable>
+              {hasError && (
+                <View style={styles.errorBox}>
+                  <Text style={styles.errorText}>
+                    {t.auth.invalidCredentials}
+                  </Text>
+                </View>
+              )}
+
+              <Button
+                title={t.auth.login}
+                onPress={() => loginMutation.mutate()}
+                loading={loginMutation.isPending}
+                disabled={!email.trim() || !password.trim()}
+                size="lg"
+              />
+
+              <View style={styles.linkRow}>
+                <Body size="sm" style={{ color: c.textLight }}>
+                  {t.auth.noAccount}{" "}
+                </Body>
+                <Pressable onPress={() => router.push("/(auth)/register")}>
+                  <Text style={styles.linkText}>{t.auth.register}</Text>
+                </Pressable>
+              </View>
             </View>
-          </View>
-        </ScrollView>
+          </ScrollView>
+        </Sheet>
       </KeyboardAvoidingView>
     </View>
   );
@@ -219,15 +222,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginTop: 4,
   },
-  sheetWrap: {
+  kavWrap: {
     flex: 1,
-    marginTop: -SHEET_OVERLAP,
-  },
-  sheet: {
-    flex: 1,
-    backgroundColor: ds.surface,
-    borderTopLeftRadius: radius["3xl"],
-    borderTopRightRadius: radius["3xl"],
   },
   sheetContent: {
     flexGrow: 1,

--- a/packages/psychologist-mobapp/app/(auth)/register.tsx
+++ b/packages/psychologist-mobapp/app/(auth)/register.tsx
@@ -11,7 +11,7 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation } from "@tanstack/react-query";
-import { Text, Input, Button } from "../../components/ui";
+import { Text, Input, Button, Sheet, Body } from "../../components/ui";
 import { colors as ds, radius, spacing } from "@tirek/shared/design-system";
 import { useT, useLanguage } from "../../lib/hooks/useLanguage";
 import { authApi } from "../../lib/api/auth";
@@ -94,11 +94,11 @@ export default function RegisterScreen() {
 
       {/* Sheet */}
       <KeyboardAvoidingView
-        style={styles.sheetWrap}
+        style={styles.kavWrap}
         behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
+        <Sheet variant="over-hero" overlap={SHEET_OVERLAP}>
         <ScrollView
-          style={styles.sheet}
           contentContainerStyle={styles.sheetContent}
           keyboardShouldPersistTaps="handled"
         >
@@ -232,15 +232,16 @@ export default function RegisterScreen() {
             />
 
             <View style={styles.linkRow}>
-              <Text variant="small" style={{ color: c.textLight }}>
+              <Body size="sm" style={{ color: c.textLight }}>
                 {t.auth.alreadyHaveAccount}{" "}
-              </Text>
+              </Body>
               <Pressable onPress={() => router.replace("/(auth)/login")}>
                 <Text style={styles.linkText}>{t.auth.login}</Text>
               </Pressable>
             </View>
           </View>
         </ScrollView>
+        </Sheet>
       </KeyboardAvoidingView>
     </View>
   );
@@ -301,15 +302,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginTop: 4,
   },
-  sheetWrap: {
+  kavWrap: {
     flex: 1,
-    marginTop: -SHEET_OVERLAP,
-  },
-  sheet: {
-    flex: 1,
-    backgroundColor: ds.surface,
-    borderTopLeftRadius: radius["3xl"],
-    borderTopRightRadius: radius["3xl"],
   },
   sheetContent: {
     flexGrow: 1,

--- a/packages/psychologist-mobapp/components/ui/Card.tsx
+++ b/packages/psychologist-mobapp/components/ui/Card.tsx
@@ -1,25 +1,43 @@
-import { View, type ViewProps } from "react-native";
+import { View, Platform, type ViewProps, type ViewStyle } from "react-native";
 import { useThemeColors, radius, spacing } from "../../lib/theme";
-import { shadow } from "../../lib/theme/shadows";
+import { shadow as shadowFn } from "../../lib/theme/shadows";
+import { shadow as dsShadow } from "@tirek/shared/design-system";
+
+export type CardVariant = "default" | "floating";
 
 interface Props extends ViewProps {
+  variant?: CardVariant;
+  /** @deprecated Use variant="floating" instead. */
   elevated?: boolean;
 }
 
-export function Card({ elevated = false, style, children, ...props }: Props) {
+function ctaShadow(): ViewStyle {
+  if (Platform.OS === "android") {
+    return { elevation: dsShadow.cta.elevation };
+  }
+  return {
+    shadowColor: dsShadow.cta.color,
+    shadowOffset: dsShadow.cta.offset,
+    shadowOpacity: dsShadow.cta.opacity,
+    shadowRadius: dsShadow.cta.radius,
+  };
+}
+
+export function Card({ variant, elevated, style, children, ...props }: Props) {
   const c = useThemeColors();
+  const resolved: CardVariant = variant ?? (elevated ? "floating" : "default");
 
   return (
     <View
       style={[
         {
-          borderRadius: radius.lg,
+          borderRadius: radius.md,
           padding: spacing.lg,
           borderWidth: 1,
           backgroundColor: c.surface,
-          borderColor: elevated ? c.border : c.borderLight,
+          borderColor: resolved === "floating" ? c.border : c.borderLight,
         },
-        elevated ? shadow(2) : shadow(1),
+        resolved === "floating" ? ctaShadow() : shadowFn(1),
         style,
       ]}
       {...props}

--- a/packages/psychologist-mobapp/components/ui/Input.tsx
+++ b/packages/psychologist-mobapp/components/ui/Input.tsx
@@ -8,50 +8,68 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { useState, type ComponentProps } from "react";
 import { useThemeColors, radius } from "../../lib/theme";
+import { Text } from "./Text";
 
 type IoniconsName = ComponentProps<typeof Ionicons>["name"];
 
 interface Props extends TextInputProps {
   icon?: IoniconsName;
+  error?: boolean;
+  helperText?: string;
   containerStyle?: ViewStyle;
 }
 
-export function Input({ icon, containerStyle, style, ...props }: Props) {
+export function Input({ icon, error, helperText, containerStyle, style, ...props }: Props) {
   const c = useThemeColors();
   const [focused, setFocused] = useState(false);
 
+  const borderColor = error
+    ? c.danger
+    : focused
+      ? c.primary
+      : c.borderLight;
+
   return (
-    <View
-      style={[
-        styles.container,
-        {
-          borderColor: focused ? c.primary : c.borderLight,
-          backgroundColor: c.surface,
-        },
-        containerStyle,
-      ]}
-    >
-      {icon && (
-        <Ionicons
-          name={icon}
-          size={18}
-          color={focused ? c.primary : c.textLight}
-          style={styles.icon}
+    <View style={containerStyle}>
+      <View
+        style={[
+          styles.container,
+          {
+            borderColor,
+            backgroundColor: c.surface,
+          },
+        ]}
+      >
+        {icon && (
+          <Ionicons
+            name={icon}
+            size={18}
+            color={error ? c.danger : focused ? c.primary : c.textLight}
+            style={styles.icon}
+          />
+        )}
+        <TextInput
+          placeholderTextColor={c.textLight}
+          style={[styles.input, { color: c.text }, icon && styles.inputWithIcon, style]}
+          onFocus={(e) => {
+            setFocused(true);
+            props.onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setFocused(false);
+            props.onBlur?.(e);
+          }}
+          {...props}
         />
+      </View>
+      {helperText && (
+        <Text
+          variant="bodyXs"
+          style={{ color: error ? c.danger : c.textLight, marginTop: 6, marginLeft: 4 }}
+        >
+          {helperText}
+        </Text>
       )}
-      <TextInput
-        placeholderTextColor={c.textLight}
-        style={[styles.input, { color: c.text }, icon && styles.inputWithIcon, style]}
-        onFocus={(e) => {
-          setFocused(true);
-          props.onFocus?.(e);
-        }}
-        onBlur={(e) => {
-          setFocused(false);
-          props.onBlur?.(e);
-        }}
-        {...props}
-      />
     </View>
   );
 }

--- a/packages/psychologist-mobapp/components/ui/Pill.tsx
+++ b/packages/psychologist-mobapp/components/ui/Pill.tsx
@@ -1,0 +1,52 @@
+import { View, type ViewProps, type TextStyle } from "react-native";
+import { Text } from "./Text";
+import { radius, fontSize, fontWeight } from "@tirek/shared/design-system";
+import { useThemeColors } from "../../lib/theme";
+import { colors as ds } from "@tirek/shared/design-system";
+
+export type PillVariant = "brand" | "success" | "warning" | "danger";
+
+interface Props extends ViewProps {
+  label: string;
+  variant?: PillVariant;
+}
+
+export function Pill({ label, variant = "brand", style, ...props }: Props) {
+  const c = useThemeColors();
+
+  const palette: Record<PillVariant, { bg: string; fg: string }> = {
+    brand: { bg: ds.brandSoft, fg: c.primary },
+    success: { bg: ds.successSoft, fg: c.success },
+    warning: { bg: ds.warningSoft, fg: c.warning },
+    danger: { bg: ds.dangerSoft, fg: c.danger },
+  };
+
+  const tone = palette[variant];
+
+  return (
+    <View
+      style={[
+        {
+          alignSelf: "flex-start",
+          backgroundColor: tone.bg,
+          borderRadius: radius.pill,
+          paddingHorizontal: 10,
+          paddingVertical: 4,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      <Text
+        style={{
+          color: tone.fg,
+          fontSize: fontSize.xs,
+          fontWeight: fontWeight.bold as TextStyle["fontWeight"],
+          letterSpacing: 0.2,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}

--- a/packages/psychologist-mobapp/components/ui/Sheet.tsx
+++ b/packages/psychologist-mobapp/components/ui/Sheet.tsx
@@ -1,0 +1,38 @@
+import { View, type ViewProps } from "react-native";
+import { useThemeColors, radius } from "../../lib/theme";
+
+export type SheetVariant = "bottom" | "over-hero";
+
+interface Props extends ViewProps {
+  variant?: SheetVariant;
+  /** Negative top margin for over-hero variant (overlap hero by N px). */
+  overlap?: number;
+}
+
+export function Sheet({
+  variant = "bottom",
+  overlap = 32,
+  style,
+  children,
+  ...props
+}: Props) {
+  const c = useThemeColors();
+
+  return (
+    <View
+      style={[
+        {
+          flex: 1,
+          backgroundColor: c.surface,
+          borderTopLeftRadius: radius["3xl"],
+          borderTopRightRadius: radius["3xl"],
+          marginTop: variant === "over-hero" ? -overlap : 0,
+        },
+        style,
+      ]}
+      {...props}
+    >
+      {children}
+    </View>
+  );
+}

--- a/packages/psychologist-mobapp/components/ui/Typography.tsx
+++ b/packages/psychologist-mobapp/components/ui/Typography.tsx
@@ -1,0 +1,22 @@
+import { Text } from "./Text";
+import type { TextProps } from "react-native";
+
+export const H1 = (props: TextProps) => <Text variant="dsH1" {...props} />;
+export const H2 = (props: TextProps) => <Text variant="dsH2" {...props} />;
+export const H3 = (props: TextProps) => <Text variant="dsH3" {...props} />;
+export const H4 = (props: TextProps) => <Text variant="dsH4" {...props} />;
+
+type BodySize = "md" | "sm" | "xs";
+const bodyVariant: Record<BodySize, "bodyMd" | "bodySm" | "bodyXs"> = {
+  md: "bodyMd",
+  sm: "bodySm",
+  xs: "bodyXs",
+};
+
+export const Body = ({ size = "md", ...props }: TextProps & { size?: BodySize }) => (
+  <Text variant={bodyVariant[size]} {...props} />
+);
+
+export const Caption = (props: TextProps) => <Text variant="caption" {...props} />;
+export const Eyebrow = (props: TextProps) => <Text variant="eyebrow" {...props} />;
+export const Label = (props: TextProps) => <Text variant="label" {...props} />;

--- a/packages/psychologist-mobapp/components/ui/index.ts
+++ b/packages/psychologist-mobapp/components/ui/index.ts
@@ -1,7 +1,10 @@
 export { Text } from "./Text";
+export { H1, H2, H3, H4, Body, Caption, Eyebrow, Label } from "./Typography";
 export { Button } from "./Button";
 export { Card } from "./Card";
+export { Pill } from "./Pill";
 export { Input } from "./Input";
+export { Sheet } from "./Sheet";
 export { Badge } from "./Badge";
 export { SeverityBadge } from "./SeverityBadge";
 export { StatusBadge } from "./StatusBadge";

--- a/packages/psychologist-mobapp/lib/theme/spacing.ts
+++ b/packages/psychologist-mobapp/lib/theme/spacing.ts
@@ -13,5 +13,7 @@ export const radius = {
   md: 12,
   lg: 16,
   xl: 24,
+  "2xl": 28,
+  "3xl": 32,
   full: 9999,
 } as const;


### PR DESCRIPTION
## Summary
- Typography pack врапперы (`<H1>`..`<H4>`, `<Body size>`, `<Caption>`, `<Eyebrow>`, `<Label>`) поверх существующего `<Text variant=...>`. Размеры по ADR-007.
- `<Card>` получил variants `default`/`floating`. `floating` использует brand-tinted `shadow-cta` (ADR-005). `elevated` prop оставлен deprecated для совместимости.
- `<Pill>` — новый, 4 variants (brand/success/warning/danger) c semantics ADR-003.
- `<Input>` расширен: `error` state (`--danger` border + helperText) и `helperText` prop.
- `<Sheet>` — новый, варианты `bottom` и `over-hero`. Скруглён сверху на `radius.3xl`. `over-hero` тянет negative margin для split-screen паттерна.
- LoginPage и RegisterPage переехали на `<Sheet variant="over-hero">`; inputs получают `error` при auth-ошибке; `<Text variant="small">` → `<Body size="sm">`.

Refs #49. Closes #52.

## Architectural notes
- ADR-012 (обновлённый после #51): UI-компоненты в `packages/psychologist-mobapp/components/ui/`, не в shared. Все 5 компонентов размещены там.
- ADR-019: фичи не трогали — только заменили inline-стили на DS-обёртки.
- `lib/theme/spacing.ts` пополнен `radius.3xl: 32` для Sheet.

## Test plan
- [ ] `pnpm tsc` зелёный по новым/изменённым файлам (pre-existing ошибки в `AiReportCard.tsx` не от этого PR; общее число ошибок: main=23, branch=19).
- [ ] Запустить `pnpm --filter @tirek/psychologist-mobapp ios` и проверить:
  - [ ] LoginPage рендерится: hero → sheet over-hero, inputs с email/password.
  - [ ] При вводе неправильных credentials — Input border краснеет (`error` prop).
  - [ ] RegisterPage аналогично, password strength bars остаются.
  - [ ] Скруглённые верхние углы sheet видны.
- [ ] Проверить, что Typography врапперы (`<H1>`..) не сломали других экранов (они не использовались — добавлены, не заменены).

🤖 Generated with [Claude Code](https://claude.com/claude-code)