### PR TITLE
DS migration · StudentsList + <MoodScale> (closes #55)

### DIFF
--- a/docs/design-system-decisions.md
+++ b/docs/design-system-decisions.md
@@ -449,7 +449,11 @@ DS фиксирует только размер (24×24 default) и stroke (2px)
 - StudentDetail (`(screens)/students/[id].tsx`): в кратком header — шкала. **MoodSparkline (график за 7 дней) остаётся как есть** — это другая визуализация для другого контекста (см. `feedback_mood_visualization`).
 - В web psy-app (по `feedback_mobapp_in_visualization_scope` — UI/visualization issues включают и web): аналогичная шкала в `StudentsListPage`.
 
-**Компонент в shared:** `<MoodScale value={1-5} />` — кладём в `@tirek/shared/components` как универсальную шкалу 1-5. Может переиспользоваться, например, для оценки риска и других уровневых индикаторов.
+**Компонент в каждом app (не в shared, см. ADR-012 и `feedback_no_shared_components`):** `<MoodScale value={1-5} />` — две копии:
+- `packages/psychologist-mobapp/components/ui/MoodScale.tsx` (RN/StyleSheet, через `useThemeColors`).
+- `packages/psychologist-app/src/components/ui/MoodScale.tsx` (Tailwind: `bg-primary` / `bg-hairline`).
+
+Дублирование 30 строк дешевле resolution-хаков для cross-platform shared component. Если шкала понадобится в stu-app/stu-mobapp — копируется ещё раз.
 
 **Что трогаем у emoji:** удаляем `moodEmojis` map из `(tabs)/students.tsx` и `[id].tsx`, заменяем на `<MoodScale>`. **Это исключение из правила ADR-019** — мы перекрашиваем, а не вырезаем фичу. Mood **остаётся** в UI, меняется только его визуальное представление. Согласовано.
 

--- a/packages/psychologist-app/src/components/ui/MoodScale.tsx
+++ b/packages/psychologist-app/src/components/ui/MoodScale.tsx
@@ -1,0 +1,28 @@
+export type MoodValue = 1 | 2 | 3 | 4 | 5;
+
+interface Props {
+  value: MoodValue;
+}
+
+const SEGMENTS = 5;
+
+export function MoodScale({ value }: Props) {
+  return (
+    <div
+      role="img"
+      aria-label={`Настроение ${value} из ${SEGMENTS}`}
+      className="inline-flex items-center gap-0.5"
+    >
+      {Array.from({ length: SEGMENTS }, (_, i) => (
+        <span
+          key={i}
+          aria-hidden
+          className={
+            "block h-2.5 w-1.5 rounded-[4px] " +
+            (i < value ? "bg-primary" : "bg-hairline")
+          }
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/psychologist-app/src/pages/StudentsListPage.tsx
+++ b/packages/psychologist-app/src/pages/StudentsListPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router";
 import { useT } from "../hooks/useLanguage.js";
 import { getStudents } from "../api/students.js";
 import { StatusBadge } from "../components/ui/StatusBadge.js";
+import { MoodScale } from "../components/ui/MoodScale.js";
 import { Search, Filter, Users, Loader2, ChevronRight, Plus } from "lucide-react";
 import { clsx } from "clsx";
 import { ErrorState } from "../components/ui/ErrorState.js";
@@ -16,14 +17,6 @@ import {
 type SortField = "name" | "class" | "status" | "lastActive";
 type SortDir = "asc" | "desc";
 type Segment = "active" | "pending";
-
-const moodEmojis: Record<number, string> = {
-  1: "\u{1F622}",
-  2: "\u{1F61F}",
-  3: "\u{1F610}",
-  4: "\u{1F60A}",
-  5: "\u{1F929}",
-};
 
 export function StudentsListPage() {
   const t = useT();
@@ -234,11 +227,13 @@ export function StudentsListPage() {
                           : "—"}
                       </span>
                       <span className="text-xs text-text-light">&middot;</span>
-                      <span className="text-xs text-text-light">
-                        {student.lastMood != null
-                          ? moodEmojis[student.lastMood] ?? "—"
-                          : "—"}
-                      </span>
+                      {student.lastMood != null ? (
+                        <MoodScale
+                          value={student.lastMood as 1 | 2 | 3 | 4 | 5}
+                        />
+                      ) : (
+                        <span className="text-xs text-text-light">—</span>
+                      )}
                       <span className="text-xs text-text-light">&middot;</span>
                       <span className="text-xs text-text-light">
                         {formatDate(student.lastActive)}

--- a/packages/psychologist-mobapp/app/(tabs)/students.tsx
+++ b/packages/psychologist-mobapp/app/(tabs)/students.tsx
@@ -11,7 +11,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useT } from "../../lib/hooks/useLanguage";
-import { Text, Input, StatusBadge } from "../../components/ui";
+import { Text, Input, StatusBadge, H3, Body, MoodScale } from "../../components/ui";
 import { SkeletonList } from "../../components/Skeleton";
 import { ErrorState } from "../../components/ErrorState";
 import { FiltersSheet } from "../../components/student/FiltersSheet";
@@ -27,14 +27,6 @@ import { inactivityApi } from "../../lib/api/inactivity";
 import { hapticLight } from "../../lib/haptics";
 
 type Segment = "active" | "pending";
-
-const moodEmojis: Record<number, string> = {
-  1: "\u{1F622}",
-  2: "\u{1F61F}",
-  3: "\u{1F610}",
-  4: "\u{1F60A}",
-  5: "\u{1F929}",
-};
 
 export default function StudentsScreen() {
   const t = useT();
@@ -136,7 +128,7 @@ export default function StudentsScreen() {
       edges={["top"]}
     >
       <View style={styles.header}>
-        <Text variant="h1">{t.psychologist.students}</Text>
+        <H3>{t.psychologist.students}</H3>
         {segment === "active" && (
           <Pressable
             onPress={() => {
@@ -184,15 +176,15 @@ export default function StudentsScreen() {
             },
           ]}
         >
-          <Text
-            variant="small"
+          <Body
+            size="sm"
             style={{
-              fontFamily: "DMSans-SemiBold",
+              fontWeight: "600",
               color: segment === "active" ? c.text : c.textLight,
             }}
           >
             {t.psychologist.studentsTabActive}
-          </Text>
+          </Body>
         </Pressable>
         <Pressable
           onPress={() => {
@@ -207,15 +199,15 @@ export default function StudentsScreen() {
             },
           ]}
         >
-          <Text
-            variant="small"
+          <Body
+            size="sm"
             style={{
-              fontFamily: "DMSans-SemiBold",
+              fontWeight: "600",
               color: segment === "pending" ? c.text : c.textLight,
             }}
           >
             {t.psychologist.studentsTabPending}
-          </Text>
+          </Body>
         </Pressable>
       </View>
 
@@ -280,28 +272,27 @@ export default function StudentsScreen() {
                       { backgroundColor: `${c.primary}1A` },
                     ]}
                   >
-                    <Text
+                    <Body
+                      size="sm"
                       style={{
-                        fontSize: 14,
-                        fontFamily: "DMSans-SemiBold",
+                        fontWeight: "600",
                         color: c.primary,
                       }}
                     >
                       {student.name.charAt(0).toUpperCase()}
-                    </Text>
+                    </Body>
                   </View>
                   <View style={styles.cardInfo}>
                     <View style={styles.nameRow}>
-                      <Text
-                        variant="body"
+                      <Body
                         style={{
-                          fontFamily: "DMSans-SemiBold",
+                          fontWeight: "600",
                           flexShrink: 1,
                         }}
                         numberOfLines={1}
                       >
                         {student.name}
-                      </Text>
+                      </Body>
                       <StatusBadge status={student.status} size="sm" />
                       {inactiveIds.has(student.id) && (
                         <View
@@ -327,23 +318,25 @@ export default function StudentsScreen() {
                       )}
                     </View>
                     <View style={styles.metaRow}>
-                      <Text variant="caption">
+                      <Body size="xs" style={{ color: c.textLight }}>
                         {student.grade != null
                           ? `${student.grade}${student.classLetter ?? ""}`
                           : "—"}
-                      </Text>
-                      <Text variant="caption"> · </Text>
-                      <Text variant="caption">
-                        {student.lastMood != null
-                          ? (moodEmojis[student.lastMood] ?? "—")
-                          : "—"}
-                      </Text>
-                      <Text variant="caption"> · </Text>
-                      <Text variant="caption">
+                      </Body>
+                      <Body size="xs" style={{ color: c.textLight }}> · </Body>
+                      {student.lastMood != null ? (
+                        <MoodScale
+                          value={student.lastMood as 1 | 2 | 3 | 4 | 5}
+                        />
+                      ) : (
+                        <Body size="xs" style={{ color: c.textLight }}>—</Body>
+                      )}
+                      <Body size="xs" style={{ color: c.textLight }}> · </Body>
+                      <Body size="xs" style={{ color: c.textLight }}>
                         {student.lastActive
                           ? new Date(student.lastActive).toLocaleDateString()
                           : "—"}
-                      </Text>
+                      </Body>
                     </View>
                   </View>
                   <Ionicons
@@ -378,15 +371,15 @@ export default function StudentsScreen() {
           ]}
         >
           <Ionicons name="add" size={18} color="#FFF" />
-          <Text
+          <Body
+            size="sm"
             style={{
               color: "#FFF",
-              fontFamily: "DMSans-SemiBold",
-              fontSize: 14,
+              fontWeight: "600",
             }}
           >
             {t.psychologist.addNewStudent}
-          </Text>
+          </Body>
         </Pressable>
       </View>
 

--- a/packages/psychologist-mobapp/components/ui/MoodScale.tsx
+++ b/packages/psychologist-mobapp/components/ui/MoodScale.tsx
@@ -1,0 +1,43 @@
+import { View, type AccessibilityProps } from "react-native";
+import { radius, colors as ds } from "@tirek/shared/design-system";
+import { useThemeColors } from "../../lib/theme";
+
+export type MoodValue = 1 | 2 | 3 | 4 | 5;
+
+interface Props extends AccessibilityProps {
+  value: MoodValue;
+}
+
+const SEGMENTS = 5;
+const SEGMENT_WIDTH = 6;
+const SEGMENT_HEIGHT = 10;
+const SEGMENT_GAP = 2;
+
+export function MoodScale({ value, accessibilityLabel, ...props }: Props) {
+  const c = useThemeColors();
+
+  return (
+    <View
+      accessibilityRole="image"
+      accessibilityLabel={accessibilityLabel ?? `Настроение ${value} из ${SEGMENTS}`}
+      style={{
+        flexDirection: "row",
+        gap: SEGMENT_GAP,
+        alignItems: "center",
+      }}
+      {...props}
+    >
+      {Array.from({ length: SEGMENTS }, (_, i) => (
+        <View
+          key={i}
+          style={{
+            width: SEGMENT_WIDTH,
+            height: SEGMENT_HEIGHT,
+            borderRadius: radius.xs,
+            backgroundColor: i < value ? c.primary : ds.hairline,
+          }}
+        />
+      ))}
+    </View>
+  );
+}

--- a/packages/psychologist-mobapp/components/ui/index.ts
+++ b/packages/psychologist-mobapp/components/ui/index.ts
@@ -8,3 +8,5 @@ export { Sheet } from "./Sheet";
 export { Badge } from "./Badge";
 export { SeverityBadge } from "./SeverityBadge";
 export { StatusBadge } from "./StatusBadge";
+export { MoodScale } from "./MoodScale";
+export type { MoodValue } from "./MoodScale";


### PR DESCRIPTION
## Summary

- Замена mood-эмодзи на 5-сегментную шкалу `<MoodScale>` (mobapp + web), карточка студента и шапка переведены на DS-токены.
- Новый компонент `<MoodScale value={1-5} />` — две копии в каждом app (по ADR-012 и `feedback_no_shared_components`); цвета намеренно не-семантические, риск-сигнал решает `StatusBadge`.
- Мигрировано as-is (ADR-019): сегменты Active/Pending, sticky-кнопка добавления, фильтры в bottom-sheet — keep, перекрашены через façade.

## Что внутри

**Mobapp** `(tabs)/students.tsx`:
- `moodEmojis` map удалён, в meta-row карточки рендерится `<MoodScale>` или `—`.
- Header `<Text variant="h1">` (legacy 24/700) → `<H3>` (DS 24/32) — как в #54.
- DMSans-SemiBold → Inter (сегменты, name, avatar, sticky-кнопка) через `<Body fontWeight 600>`.

**Web** `StudentsListPage.tsx`:
- `moodEmojis` map удалён, в meta-row карточки рендерится `<MoodScale>` или `—`.
- Tailwind-токены (`bg-primary`, `text-text-light`) уже DS-façade — больше ничего не трогал.

**Новые компоненты:**
- `packages/psychologist-mobapp/components/ui/MoodScale.tsx` (RN/StyleSheet, использует `useThemeColors`).
- `packages/psychologist-app/src/components/ui/MoodScale.tsx` (Tailwind: `bg-primary` / `bg-hairline`).

## ADR-021 нюанс

ADR-021 предписывал `<MoodScale>` в `packages/shared/src/components/`. Это устарело: после #52 все UI-компоненты живут в каждом app отдельно (см. `feedback_no_shared_components`, ADR-012 в обновлённой редакции). Дублирование 30 строк дешевле resolution-хаков для shared+react-native.

## Acceptance criteria (из #55)

- [x] `<MoodScale>` создан в каждом app (вместо shared).
- [x] Mobapp: emoji удалены, шкала на месте.
- [x] Web: emoji удалены, шкала на месте.
- [x] Active/Pending сегменты работают (не тронуты, только текст в `<Body>`).
- [x] Sticky-кнопка "Добавить ученика" работает (не тронута).
- [x] Фильтры в bottom-sheet работают (`<FiltersSheet>` не тронут).
- [x] Цвета через façade (`useThemeColors` mobapp, Tailwind tokens web).

## Test plan

- [ ] Mobapp: открыть таб «Ученики», убедиться что у активных учеников вместо эмодзи появилась 5-сегментная teal-шкала; шапка осталась 24px, не 48px.
- [ ] Mobapp: переключить Active/Pending — сегменты, отступы, тени без регрессий.
- [ ] Mobapp: открыть фильтры — bottom-sheet работает.
- [ ] Mobapp: тапнуть «Добавить ученика» — sticky-кнопка работает, sheet открывается.
- [ ] Mobapp: ученик без mood (`lastMood = null`) — на месте `—`, не падает.
- [ ] Web: то же самое в браузере (`/students`).
- [ ] TS: `tsc --noEmit` чисто (релевантных ошибок нет — старые ошибки в AiReportCard не задеты).

🤖 Generated with [Claude Code](https://claude.com/claude-code)