### PR TITLE
feat(ds): DiagnosticsPage + sub-screens → DS façade (closes #58)

### DIFF
--- a/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-class.tsx
+++ b/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-class.tsx
@@ -13,7 +13,7 @@ import { useRouter, Stack, useLocalSearchParams } from "expo-router";
 import { useMutation } from "@tanstack/react-query";
 import { testDefinitions } from "@tirek/shared";
 import { useT, useLanguage } from "../../../lib/hooks/useLanguage";
-import { Text } from "../../../components/ui";
+import { Text, Button } from "../../../components/ui";
 import { useThemeColors, radius } from "../../../lib/theme";
 import { diagnosticsApi } from "../../../lib/api/diagnostics";
 import { hapticLight } from "../../../lib/haptics";
@@ -144,7 +144,7 @@ export default function AssignToClassScreen() {
                   <Text
                     variant="small"
                     style={{
-                      fontFamily: "DMSans-SemiBold",
+                      fontWeight: "600",
                       color: active ? "#FFF" : c.textLight,
                     }}
                   >
@@ -179,7 +179,7 @@ export default function AssignToClassScreen() {
               <Text
                 variant="small"
                 style={{
-                  fontFamily: "DMSans-SemiBold",
+                  fontWeight: "600",
                   color: classLetter === "" ? "#FFF" : c.textLight,
                 }}
               >
@@ -205,7 +205,7 @@ export default function AssignToClassScreen() {
                   <Text
                     variant="small"
                     style={{
-                      fontFamily: "DMSans-SemiBold",
+                      fontWeight: "600",
                       color: active ? "#FFF" : c.textLight,
                     }}
                   >
@@ -298,25 +298,15 @@ export default function AssignToClassScreen() {
             </View>
           )}
 
-          <Pressable
-            onPress={() => {
-              hapticLight();
-              mutation.mutate();
-            }}
+          <Button
+            title={submitLabel}
+            variant="primary"
+            size="lg"
+            onPress={() => mutation.mutate()}
             disabled={!canSubmit}
-            style={[
-              styles.submitBtn,
-              { backgroundColor: canSubmit ? c.primary : `${c.primary}60` },
-            ]}
-          >
-            {mutation.isPending && (
-              <Ionicons name="reload-outline" size={16} color="#FFF" />
-            )}
-            <Ionicons name="clipboard-outline" size={16} color="#FFF" />
-            <Text style={styles.submitText} numberOfLines={1}>
-              {submitLabel}
-            </Text>
-          </Pressable>
+            loading={mutation.isPending}
+            style={{ marginTop: 16 }}
+          />
         </ScrollView>
       </KeyboardAvoidingView>
     </>
@@ -333,7 +323,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   fieldLabel: {
-    fontFamily: "DMSans-SemiBold",
+    fontWeight: "600",
     marginBottom: 4,
     marginTop: 8,
   },
@@ -368,7 +358,7 @@ const styles = StyleSheet.create({
   dateText: {
     flex: 1,
     fontSize: 14,
-    fontFamily: "DMSans-Regular",
+    fontFamily: "Inter_400Regular",
     padding: 0,
   },
   clearBtn: {
@@ -387,28 +377,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 10,
     fontSize: 14,
-    fontFamily: "DMSans-Regular",
+    fontFamily: "Inter_400Regular",
     textAlignVertical: "top",
   },
   errorBanner: {
     padding: 12,
     borderRadius: radius.sm,
     marginTop: 8,
-  },
-  submitBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 8,
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    borderRadius: radius.md,
-    marginTop: 16,
-  },
-  submitText: {
-    color: "#FFF",
-    fontSize: 14,
-    fontFamily: "DMSans-SemiBold",
   },
   successContainer: {
     flex: 1,

--- a/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-student.tsx
+++ b/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-student.tsx
@@ -13,7 +13,7 @@ import { useRouter, Stack, useLocalSearchParams } from "expo-router";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { testDefinitions } from "@tirek/shared";
 import { useT, useLanguage } from "../../../lib/hooks/useLanguage";
-import { Text, Input } from "../../../components/ui";
+import { Text, Input, Button } from "../../../components/ui";
 import { useThemeColors, radius } from "../../../lib/theme";
 import { diagnosticsApi } from "../../../lib/api/diagnostics";
 import { studentsApi } from "../../../lib/api/students";
@@ -180,7 +180,7 @@ export default function AssignToStudentScreen() {
                         <Text
                           style={{
                             fontSize: 10,
-                            fontFamily: "DMSans-SemiBold",
+                            fontWeight: "600",
                             color: c.primary,
                           }}
                         >
@@ -301,25 +301,15 @@ export default function AssignToStudentScreen() {
             </View>
           )}
 
-          <Pressable
-            onPress={() => {
-              hapticLight();
-              mutation.mutate();
-            }}
+          <Button
+            title={submitLabel}
+            variant="primary"
+            size="lg"
+            onPress={() => mutation.mutate()}
             disabled={!canSubmit}
-            style={[
-              styles.submitBtn,
-              { backgroundColor: canSubmit ? c.primary : `${c.primary}60` },
-            ]}
-          >
-            {mutation.isPending && (
-              <Ionicons name="reload-outline" size={16} color="#FFF" />
-            )}
-            <Ionicons name="clipboard-outline" size={16} color="#FFF" />
-            <Text style={styles.submitText} numberOfLines={1}>
-              {submitLabel}
-            </Text>
-          </Pressable>
+            loading={mutation.isPending}
+            style={{ marginTop: 16 }}
+          />
         </ScrollView>
       </KeyboardAvoidingView>
     </>
@@ -336,7 +326,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   fieldLabel: {
-    fontFamily: "DMSans-SemiBold",
+    fontWeight: "600",
     marginBottom: 4,
     marginTop: 8,
   },
@@ -382,7 +372,7 @@ const styles = StyleSheet.create({
   dateText: {
     flex: 1,
     fontSize: 14,
-    fontFamily: "DMSans-Regular",
+    fontFamily: "Inter_400Regular",
     padding: 0,
   },
   clearBtn: {
@@ -401,28 +391,13 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 10,
     fontSize: 14,
-    fontFamily: "DMSans-Regular",
+    fontFamily: "Inter_400Regular",
     textAlignVertical: "top",
   },
   errorBanner: {
     padding: 12,
     borderRadius: radius.sm,
     marginTop: 8,
-  },
-  submitBtn: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 8,
-    paddingVertical: 14,
-    paddingHorizontal: 16,
-    borderRadius: radius.md,
-    marginTop: 16,
-  },
-  submitText: {
-    color: "#FFF",
-    fontSize: 14,
-    fontFamily: "DMSans-SemiBold",
   },
   successContainer: {
     flex: 1,

--- a/packages/psychologist-mobapp/app/(screens)/diagnostics/test/[slug].tsx
+++ b/packages/psychologist-mobapp/app/(screens)/diagnostics/test/[slug].tsx
@@ -3,9 +3,10 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { testDefinitions } from "@tirek/shared";
-import { Text } from "../../../../components/ui";
+import { Text, Button } from "../../../../components/ui";
 import { useT, useLanguage } from "../../../../lib/hooks/useLanguage";
 import { useThemeColors, radius } from "../../../../lib/theme";
+import { colors as ds } from "@tirek/shared/design-system";
 import { hapticLight } from "../../../../lib/haptics";
 
 export default function TestDetailScreen() {
@@ -58,7 +59,7 @@ export default function TestDetailScreen() {
     >
       <Stack.Screen options={{ title: t.psychologist.diagnostics }} />
       <ScrollView contentContainerStyle={styles.scroll}>
-        <Text variant="h2" style={{ fontFamily: "DMSans-Bold" }}>
+        <Text variant="h2" style={{ fontWeight: "700" }}>
           {name}
         </Text>
         <Text variant="body" style={{ marginTop: 6 }}>
@@ -111,14 +112,22 @@ export default function TestDetailScreen() {
         </View>
 
         {tips && (
-          <View style={styles.tipsCard}>
+          <View
+            style={[
+              styles.tipsCard,
+              {
+                backgroundColor: ds.warningSoft,
+                borderColor: `${c.warning}33`,
+              },
+            ]}
+          >
             <View style={styles.tipsHeader}>
-              <Ionicons name="bulb-outline" size={16} color="#B45309" />
+              <Ionicons name="bulb-outline" size={16} color={c.warning} />
               <Text
                 variant="body"
                 style={{
-                  fontFamily: "DMSans-Bold",
-                  color: "#92400E",
+                  fontWeight: "700",
+                  color: c.warning,
                 }}
               >
                 {t.psychologist.testWhenToAssign}
@@ -126,7 +135,7 @@ export default function TestDetailScreen() {
             </View>
             <Text
               variant="body"
-              style={{ color: "#92400E", marginTop: 6, lineHeight: 20 }}
+              style={{ color: c.text, marginTop: 6, lineHeight: 20 }}
             >
               {tips}
             </Text>
@@ -140,36 +149,22 @@ export default function TestDetailScreen() {
           { backgroundColor: c.bg, borderTopColor: c.borderLight },
         ]}
       >
-        <Pressable
-          onPress={() => goAssign("student")}
-          style={({ pressed }) => [
-            styles.primaryBtn,
-            { backgroundColor: c.primary },
-            pressed && { opacity: 0.9 },
-          ]}
-        >
-          <Text
-            variant="body"
-            style={{ color: "#FFF", fontFamily: "DMSans-SemiBold" }}
-          >
-            {t.psychologist.assignToStudentBtn}
-          </Text>
-        </Pressable>
-        <Pressable
-          onPress={() => goAssign("class")}
-          style={({ pressed }) => [
-            styles.secondaryBtn,
-            { borderColor: c.primary, backgroundColor: c.surface },
-            pressed && { opacity: 0.9 },
-          ]}
-        >
-          <Text
-            variant="body"
-            style={{ color: c.primary, fontFamily: "DMSans-SemiBold" }}
-          >
-            {t.psychologist.assignToClassBtn}
-          </Text>
-        </Pressable>
+        <View style={{ flex: 1 }}>
+          <Button
+            title={t.psychologist.assignToStudentBtn}
+            variant="primary"
+            size="md"
+            onPress={() => goAssign("student")}
+          />
+        </View>
+        <View style={{ flex: 1 }}>
+          <Button
+            title={t.psychologist.assignToClassBtn}
+            variant="secondary"
+            size="md"
+            onPress={() => goAssign("class")}
+          />
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -201,9 +196,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     padding: 14,
     borderRadius: radius.lg,
-    backgroundColor: "#FEF3C7",
     borderWidth: 1,
-    borderColor: "#FCD34D",
   },
   tipsHeader: {
     flexDirection: "row",
@@ -221,21 +214,6 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 16,
     borderTopWidth: 1,
-  },
-  primaryBtn: {
-    flex: 1,
-    height: 44,
-    borderRadius: radius.lg,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  secondaryBtn: {
-    flex: 1,
-    height: 44,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    alignItems: "center",
-    justifyContent: "center",
   },
   empty: {
     flex: 1,

--- a/packages/psychologist-mobapp/app/(tabs)/diagnostics.tsx
+++ b/packages/psychologist-mobapp/app/(tabs)/diagnostics.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { Text } from "../../components/ui";
 import { useT } from "../../lib/hooks/useLanguage";
 import { useThemeColors, radius } from "../../lib/theme";
+import { shadow } from "../../lib/theme/shadows";
 import { hapticLight } from "../../lib/haptics";
 import { CatalogSegment } from "../../components/diagnostics/CatalogSegment";
 import { AssignmentsSegment } from "../../components/diagnostics/AssignmentsSegment";
@@ -48,7 +49,7 @@ export default function DiagnosticsScreen() {
             ]}
           >
             <Ionicons name="filter-outline" size={14} color={c.text} />
-            <Text variant="small" style={{ fontFamily: "DMSans-SemiBold" }}>
+            <Text variant="small" style={{ fontWeight: "600", color: c.text }}>
               {t.psychologist.filtersTitle}
             </Text>
             {isFilterActive(filters) && (
@@ -124,20 +125,13 @@ function SegmentBtn({ label, active, onPress, c }: SegmentBtnProps) {
       }}
       style={[
         styles.segmentBtn,
-        active && {
-          backgroundColor: c.surface,
-          shadowColor: "#000",
-          shadowOpacity: 0.05,
-          shadowOffset: { width: 0, height: 1 },
-          shadowRadius: 2,
-          elevation: 1,
-        },
+        active && [{ backgroundColor: c.surface }, shadow(1)],
       ]}
     >
       <Text
         variant="small"
         style={{
-          fontFamily: "DMSans-SemiBold",
+          fontWeight: "600",
           color: active ? c.text : c.textLight,
         }}
         numberOfLines={1}

--- a/packages/psychologist-mobapp/components/diagnostics/AiReportCard.tsx
+++ b/packages/psychologist-mobapp/components/diagnostics/AiReportCard.tsx
@@ -9,8 +9,9 @@ import { Ionicons } from "@expo/vector-icons";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Text } from "../ui";
 import { Skeleton } from "../Skeleton";
-import { useThemeColors, radius } from "../../lib/theme";
+import { useThemeColors, radius, type ThemeColors } from "../../lib/theme";
 import { diagnosticsApi } from "../../lib/api/diagnostics";
+import { colors as ds } from "@tirek/shared/design-system";
 import type {
   AiReportRecommendationType,
   DiagnosticAiReport,
@@ -20,50 +21,54 @@ interface AiReportCardProps {
   sessionId: string;
 }
 
-const RISK_STYLES: Record<
+function riskStyles(c: ThemeColors): Record<
   string,
   { bg: string; text: string; label: string }
-> = {
-  low: { bg: "#ECFDF5", text: "#047857", label: "Низкий" },
-  moderate: { bg: "#FFFBEB", text: "#B45309", label: "Средний" },
-  high: { bg: "#FEF2F2", text: "#B91C1C", label: "Высокий" },
-};
+> {
+  return {
+    low: { bg: ds.successSoft, text: c.success, label: "Низкий" },
+    moderate: { bg: ds.warningSoft, text: c.warning, label: "Средний" },
+    high: { bg: ds.dangerSoft, text: c.danger, label: "Высокий" },
+  };
+}
 
-const RECOMMENDATION_META: Record<
+function recommendationMeta(c: ThemeColors): Record<
   AiReportRecommendationType,
   { icon: keyof typeof Ionicons.glyphMap; label: string; bg: string; color: string }
-> = {
-  therapy: {
-    icon: "people",
-    label: "Индивидуальная беседа",
-    bg: "#EFF6FF",
-    color: "#1D4ED8",
-  },
-  exercise: {
-    icon: "leaf",
-    label: "Упражнение",
-    bg: "#F0FDFA",
-    color: "#0F766E",
-  },
-  referral: {
-    icon: "medkit",
-    label: "Направление",
-    bg: "#FAF5FF",
-    color: "#7C3AED",
-  },
-  monitoring: {
-    icon: "trending-up",
-    label: "Наблюдение",
-    bg: "#F8FAFC",
-    color: "#475569",
-  },
-  conversation: {
-    icon: "people",
-    label: "Разговор",
-    bg: "#EEF2FF",
-    color: "#4338CA",
-  },
-};
+> {
+  return {
+    therapy: {
+      icon: "people",
+      label: "Индивидуальная беседа",
+      bg: ds.infoSoft,
+      color: c.info,
+    },
+    exercise: {
+      icon: "leaf",
+      label: "Упражнение",
+      bg: ds.successSoft,
+      color: c.success,
+    },
+    referral: {
+      icon: "medkit",
+      label: "Направление",
+      bg: ds.dangerSoft,
+      color: c.danger,
+    },
+    monitoring: {
+      icon: "trending-up",
+      label: "Наблюдение",
+      bg: c.surfaceSecondary,
+      color: c.textLight,
+    },
+    conversation: {
+      icon: "people",
+      label: "Разговор",
+      bg: ds.brandSoft,
+      color: c.primary,
+    },
+  };
+}
 
 function isReadyReport(
   r: DiagnosticAiReport | { status: "pending" } | undefined,
@@ -81,6 +86,9 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
   const c = useThemeColors();
   const queryClient = useQueryClient();
   const [flaggedOpen, setFlaggedOpen] = useState(false);
+
+  const RISK_STYLES = riskStyles(c);
+  const RECOMMENDATION_META = recommendationMeta(c);
 
   const { data: report, isLoading } = useQuery({
     queryKey: ["diagnostics", "report", sessionId],
@@ -126,11 +134,11 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
     return (
       <View style={[styles.card, { borderColor: c.borderLight, backgroundColor: c.surface }]}>
         <View style={styles.headerRow}>
-          <View style={styles.headerIcon}>
-            <ActivityIndicator size="small" color="#4F46E5" />
+          <View style={[styles.headerIcon, { backgroundColor: ds.brandSoft }]}>
+            <ActivityIndicator size="small" color={c.primary} />
           </View>
           <View>
-            <Text style={styles.headerLabel}>AI-АНАЛИЗ РЕЗУЛЬТАТА</Text>
+            <Text style={[styles.headerLabel, { color: c.primary }]}>AI-АНАЛИЗ РЕЗУЛЬТАТА</Text>
             <Text style={[styles.headerSub, { color: c.textLight }]}>
               Генерируется…
             </Text>
@@ -155,17 +163,17 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
       <View
         style={[
           styles.card,
-          { borderColor: "#FECACA", backgroundColor: "#FEF2F2" },
+          { borderColor: `${c.danger}33`, backgroundColor: ds.dangerSoft },
         ]}
       >
         <View style={{ flexDirection: "row", alignItems: "center", gap: 8 }}>
-          <Ionicons name="alert-circle" size={18} color="#B91C1C" />
-          <Text style={{ fontSize: 13, fontFamily: "DMSans-Bold", color: "#B91C1C" }}>
+          <Ionicons name="alert-circle" size={18} color={c.danger} />
+          <Text style={{ fontSize: 13, fontWeight: "700", color: c.danger }}>
             Не удалось сгенерировать отчёт
           </Text>
         </View>
         {report.errorMessage && (
-          <Text style={{ fontSize: 12, color: "#DC2626", marginTop: 8 }}>
+          <Text style={{ fontSize: 12, color: c.danger, marginTop: 8 }}>
             {report.errorMessage}
           </Text>
         )}
@@ -174,6 +182,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
           disabled={regenerate.isPending}
           style={({ pressed }) => [
             styles.retryBtn,
+            { backgroundColor: c.danger },
             pressed && { opacity: 0.8 },
             regenerate.isPending && { opacity: 0.6 },
           ]}
@@ -183,7 +192,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
           ) : (
             <Ionicons name="refresh" size={14} color="#FFF" />
           )}
-          <Text style={{ fontSize: 12, fontFamily: "DMSans-Bold", color: "#FFF" }}>
+          <Text style={{ fontSize: 12, fontWeight: "700", color: "#FFF" }}>
             Перегенерировать
           </Text>
         </Pressable>
@@ -196,11 +205,11 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
     <View style={[styles.card, { borderColor: c.borderLight, backgroundColor: c.surface }]}>
       {/* Header */}
       <View style={styles.headerRow}>
-        <View style={styles.headerIcon}>
-          <Ionicons name="hardware-chip-outline" size={18} color="#4F46E5" />
+        <View style={[styles.headerIcon, { backgroundColor: ds.brandSoft }]}>
+          <Ionicons name="hardware-chip-outline" size={18} color={c.primary} />
         </View>
         <View style={{ flex: 1 }}>
-          <Text style={styles.headerLabel}>AI-АНАЛИЗ РЕЗУЛЬТАТА</Text>
+          <Text style={[styles.headerLabel, { color: c.primary }]}>AI-АНАЛИЗ РЕЗУЛЬТАТА</Text>
           {report.generatedAt && (
             <Text style={[styles.headerSub, { color: c.textLight }]}>
               Сформировано{" "}
@@ -228,7 +237,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
           ) : (
             <Ionicons name="refresh" size={12} color={c.textLight} />
           )}
-          <Text style={{ fontSize: 11, fontFamily: "DMSans-SemiBold", color: c.textLight }}>
+          <Text style={{ fontSize: 11, fontWeight: "600", color: c.textLight }}>
             Обновить
           </Text>
         </Pressable>
@@ -295,7 +304,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
                     <Text
                       style={{
                         fontSize: 10,
-                        fontFamily: "DMSans-Bold",
+                        fontWeight: "700",
                         color: meta.text,
                       }}
                     >
@@ -306,7 +315,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
                     <Text
                       style={{
                         fontSize: 13,
-                        fontFamily: "DMSans-SemiBold",
+                        fontWeight: "600",
                         color: c.text,
                       }}
                     >
@@ -359,7 +368,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
                     <Text
                       style={{
                         fontSize: 10,
-                        fontFamily: "DMSans-Bold",
+                        fontWeight: "700",
                         textTransform: "uppercase",
                         letterSpacing: 0.5,
                         color: meta.color,
@@ -386,17 +395,25 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
 
       {/* Flagged items */}
       {flaggedWithText.length > 0 && (
-        <View style={styles.flaggedSection}>
+        <View
+          style={[
+            styles.flaggedSection,
+            {
+              borderColor: `${c.warning}33`,
+              backgroundColor: ds.warningSoft,
+            },
+          ]}
+        >
           <Pressable
             onPress={() => setFlaggedOpen(!flaggedOpen)}
             style={styles.flaggedHeader}
           >
-            <Ionicons name="warning" size={14} color="#92400E" />
+            <Ionicons name="warning" size={14} color={c.warning} />
             <Text
               style={{
                 fontSize: 13,
-                fontFamily: "DMSans-Bold",
-                color: "#92400E",
+                fontWeight: "700",
+                color: c.warning,
                 flex: 1,
               }}
             >
@@ -405,7 +422,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
             <Ionicons
               name="chevron-down"
               size={14}
-              color="#92400E"
+              color={c.warning}
               style={{
                 transform: [{ rotate: flaggedOpen ? "180deg" : "0deg" }],
               }}
@@ -416,13 +433,19 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
               {flaggedWithText.map((f, idx) => (
                 <View
                   key={idx}
-                  style={styles.flaggedItem}
+                  style={[
+                    styles.flaggedItem,
+                    {
+                      borderColor: `${c.warning}33`,
+                      backgroundColor: c.surface,
+                    },
+                  ]}
                 >
                   {f.questionText && (
                     <Text
                       style={{
                         fontSize: 12,
-                        fontFamily: "DMSans-SemiBold",
+                        fontWeight: "600",
                         color: c.text,
                       }}
                     >
@@ -434,8 +457,8 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
                       Ответ:{" "}
                       <Text
                         style={{
-                          fontFamily: "DMSans-Bold",
-                          color: "#B45309",
+                          fontWeight: "700",
+                          color: c.warning,
                         }}
                       >
                         {f.answerLabel ?? `значение ${f.answerValue}`}
@@ -488,7 +511,7 @@ function SectionTitle({
       <Text
         style={{
           fontSize: 11,
-          fontFamily: "DMSans-Bold",
+          fontWeight: "700",
           textTransform: "uppercase",
           letterSpacing: 0.5,
           color,
@@ -515,16 +538,14 @@ const styles = StyleSheet.create({
     width: 36,
     height: 36,
     borderRadius: 12,
-    backgroundColor: "#EDE9FE",
     alignItems: "center",
     justifyContent: "center",
   },
   headerLabel: {
     fontSize: 11,
-    fontFamily: "DMSans-Bold",
+    fontWeight: "700",
     textTransform: "uppercase",
     letterSpacing: 0.8,
-    color: "#4338CA",
   },
   headerSub: {
     fontSize: 11,
@@ -541,7 +562,7 @@ const styles = StyleSheet.create({
   },
   summary: {
     fontSize: 14,
-    fontFamily: "DMSans-Bold",
+    fontWeight: "700",
     lineHeight: 20,
     marginTop: 12,
   },
@@ -552,7 +573,7 @@ const styles = StyleSheet.create({
   },
   sectionLabel: {
     fontSize: 11,
-    fontFamily: "DMSans-Bold",
+    fontWeight: "700",
     textTransform: "uppercase",
     letterSpacing: 0.5,
   },
@@ -586,8 +607,6 @@ const styles = StyleSheet.create({
   flaggedSection: {
     borderRadius: 12,
     borderWidth: 1,
-    borderColor: "#FDE68A",
-    backgroundColor: "#FFFBEB",
     padding: 12,
     marginTop: 12,
   },
@@ -599,15 +618,12 @@ const styles = StyleSheet.create({
   flaggedItem: {
     borderRadius: 8,
     borderWidth: 1,
-    borderColor: "#FDE68A",
-    backgroundColor: "#FFFFFF",
     padding: 10,
   },
   retryBtn: {
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
-    backgroundColor: "#DC2626",
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 8,

--- a/packages/psychologist-mobapp/components/diagnostics/AssignmentsSegment.tsx
+++ b/packages/psychologist-mobapp/components/diagnostics/AssignmentsSegment.tsx
@@ -11,7 +11,7 @@ import {
   type TestAssignmentStatus,
 } from "../../lib/api/diagnostics";
 import { useT, useLanguage } from "../../lib/hooks/useLanguage";
-import { useThemeColors, radius } from "../../lib/theme";
+import { useThemeColors, radius, type ThemeColors } from "../../lib/theme";
 import { shadow } from "../../lib/theme/shadows";
 import { hapticLight } from "../../lib/haptics";
 
@@ -38,18 +38,18 @@ function statusKey(s: TestAssignmentStatus) {
   }
 }
 
-function statusColors(s: TestAssignmentStatus) {
+function statusColors(s: TestAssignmentStatus, c: ThemeColors) {
   switch (s) {
     case "pending":
-      return { bg: "#FEF3C7", fg: "#B45309", border: "#FCD34D" };
+      return { bg: `${c.warning}1A`, fg: c.warning, border: `${c.warning}33` };
     case "in_progress":
-      return { bg: "#DBEAFE", fg: "#1D4ED8", border: "#93C5FD" };
+      return { bg: `${c.primary}1A`, fg: c.primary, border: `${c.primary}33` };
     case "completed":
-      return { bg: "#D1FAE5", fg: "#047857", border: "#6EE7B7" };
+      return { bg: `${c.success}1A`, fg: c.success, border: `${c.success}33` };
     case "expired":
-      return { bg: "#F3F4F6", fg: "#6B7280", border: "#D1D5DB" };
+      return { bg: c.surfaceSecondary, fg: c.textLight, border: c.borderLight };
     case "cancelled":
-      return { bg: "#F3F4F6", fg: "#9CA3AF", border: "#D1D5DB" };
+      return { bg: c.surfaceSecondary, fg: c.textLight, border: c.borderLight };
   }
 }
 
@@ -134,7 +134,7 @@ export function AssignmentsSegment() {
           <Text
             variant="small"
             style={{
-              fontFamily: "DMSans-SemiBold",
+              fontWeight: "600",
               color: statusFilter === null ? "#FFF" : c.textLight,
             }}
           >
@@ -160,7 +160,7 @@ export function AssignmentsSegment() {
               <Text
                 variant="small"
                 style={{
-                  fontFamily: "DMSans-SemiBold",
+                  fontWeight: "600",
                   color: active ? "#FFF" : c.textLight,
                 }}
               >
@@ -194,7 +194,7 @@ export function AssignmentsSegment() {
           {data.map((row) => {
             const canCancel =
               row.status === "pending" || row.status === "in_progress";
-            const sc = statusColors(row.status);
+            const sc = statusColors(row.status, c);
             return (
               <View
                 key={row.id}
@@ -212,7 +212,7 @@ export function AssignmentsSegment() {
                     <Text
                       variant="body"
                       style={{
-                        fontFamily: "DMSans-SemiBold",
+                        fontWeight: "600",
                         flexShrink: 1,
                       }}
                       numberOfLines={1}
@@ -232,7 +232,6 @@ export function AssignmentsSegment() {
                         variant="caption"
                         style={{
                           color: sc.fg,
-                          fontFamily: "DMSans-Bold",
                           fontSize: 10,
                           textDecorationLine:
                             row.status === "cancelled"
@@ -287,7 +286,7 @@ export function AssignmentsSegment() {
                   >
                     <Text
                       variant="caption"
-                      style={{ fontFamily: "DMSans-SemiBold" }}
+                      style={{ fontWeight: "600" }}
                     >
                       {t.psychologist.cancelAssignment}
                     </Text>

--- a/packages/psychologist-mobapp/components/diagnostics/CatalogSegment.tsx
+++ b/packages/psychologist-mobapp/components/diagnostics/CatalogSegment.tsx
@@ -50,7 +50,7 @@ export function CatalogSegment() {
             ]}
           >
             <View style={{ flex: 1 }}>
-              <Text variant="body" style={styles.title} numberOfLines={2}>
+              <Text variant="body" style={{ fontWeight: "600" }} numberOfLines={2}>
                 {name}
               </Text>
               <Text variant="caption" numberOfLines={2} style={styles.desc}>
@@ -114,9 +114,6 @@ const styles = StyleSheet.create({
     padding: 12,
     borderRadius: radius.lg,
     borderWidth: 1,
-  },
-  title: {
-    fontFamily: "DMSans-SemiBold",
   },
   desc: {
     marginTop: 2,

--- a/packages/psychologist-mobapp/components/diagnostics/DiagnosticsFiltersSheet.tsx
+++ b/packages/psychologist-mobapp/components/diagnostics/DiagnosticsFiltersSheet.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { testDefinitions, type Severity } from "@tirek/shared";
-import { Text } from "../ui";
+import { Text, Button } from "../ui";
 import { useT, useLanguage } from "../../lib/hooks/useLanguage";
 import { useThemeColors, radius } from "../../lib/theme";
 import { hapticLight } from "../../lib/haptics";
@@ -90,7 +90,7 @@ export function DiagnosticsFiltersSheet({
             <View style={[styles.dragBar, { backgroundColor: c.border }]} />
           </View>
           <View style={styles.header}>
-            <Text variant="h3" style={{ fontFamily: "DMSans-Bold" }}>
+            <Text variant="h3" style={{ fontWeight: "700" }}>
               {t.psychologist.filtersTitle}
             </Text>
             <Pressable
@@ -166,31 +166,22 @@ export function DiagnosticsFiltersSheet({
               </View>
             </View>
             <View style={styles.actions}>
-              <Pressable
-                onPress={reset}
-                style={[
-                  styles.resetBtn,
-                  { borderColor: c.borderLight },
-                ]}
-              >
-                <Text
-                  variant="body"
-                  style={{ fontFamily: "DMSans-SemiBold", color: c.textLight }}
-                >
-                  {t.psychologist.filtersReset}
-                </Text>
-              </Pressable>
-              <Pressable
-                onPress={apply}
-                style={[styles.applyBtn, { backgroundColor: c.primary }]}
-              >
-                <Text
-                  variant="body"
-                  style={{ fontFamily: "DMSans-SemiBold", color: "#FFF" }}
-                >
-                  {t.psychologist.filtersApply}
-                </Text>
-              </Pressable>
+              <View style={{ flex: 1 }}>
+                <Button
+                  title={t.psychologist.filtersReset}
+                  variant="secondary"
+                  size="md"
+                  onPress={reset}
+                />
+              </View>
+              <View style={{ flex: 2 }}>
+                <Button
+                  title={t.psychologist.filtersApply}
+                  variant="primary"
+                  size="md"
+                  onPress={apply}
+                />
+              </View>
             </View>
           </ScrollView>
         </View>
@@ -230,7 +221,7 @@ function Section({ title, c, t, value, setValue, options }: SectionProps) {
           <Text
             variant="small"
             style={{
-              fontFamily: "DMSans-SemiBold",
+              fontWeight: "600",
               color: value === "" ? "#FFF" : c.textLight,
             }}
           >
@@ -256,7 +247,7 @@ function Section({ title, c, t, value, setValue, options }: SectionProps) {
               <Text
                 variant="small"
                 style={{
-                  fontFamily: "DMSans-SemiBold",
+                  fontWeight: "600",
                   color: active ? "#FFF" : c.textLight,
                 }}
                 numberOfLines={1}
@@ -315,7 +306,7 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   label: {
-    fontFamily: "DMSans-SemiBold",
+    fontWeight: "600",
     marginBottom: 4,
   },
   chips: {
@@ -337,27 +328,12 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: radius.sm,
     paddingHorizontal: 10,
-    fontFamily: "DMSans-Regular",
+    fontFamily: "Inter_400Regular",
     fontSize: 13,
   },
   actions: {
     flexDirection: "row",
     gap: 8,
     marginTop: 8,
-  },
-  resetBtn: {
-    flex: 1,
-    height: 44,
-    borderRadius: radius.lg,
-    borderWidth: 1,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  applyBtn: {
-    flex: 2,
-    height: 44,
-    borderRadius: radius.lg,
-    alignItems: "center",
-    justifyContent: "center",
   },
 });

--- a/packages/psychologist-mobapp/components/diagnostics/ResultsSegment.tsx
+++ b/packages/psychologist-mobapp/components/diagnostics/ResultsSegment.tsx
@@ -22,6 +22,7 @@ import { useT } from "../../lib/hooks/useLanguage";
 import { useThemeColors, radius } from "../../lib/theme";
 import { shadow } from "../../lib/theme/shadows";
 import { hapticLight } from "../../lib/haptics";
+import { colors as ds } from "@tirek/shared/design-system";
 
 interface Props {
   filters: DiagnosticsFilters;
@@ -103,7 +104,7 @@ export function ResultsSegment({ filters }: Props) {
               <Text
                 style={{
                   fontSize: 14,
-                  fontFamily: "DMSans-SemiBold",
+                  fontWeight: "600",
                   color: c.primary,
                 }}
               >
@@ -114,7 +115,7 @@ export function ResultsSegment({ filters }: Props) {
               <View style={styles.nameRow}>
                 <Text
                   variant="body"
-                  style={{ fontFamily: "DMSans-SemiBold", flexShrink: 1 }}
+                  style={{ fontWeight: "600", flexShrink: 1 }}
                   numberOfLines={1}
                 >
                   {row.studentName ?? "Student"}
@@ -144,7 +145,7 @@ export function ResultsSegment({ filters }: Props) {
             </View>
             <View style={styles.scoreCol}>
               {row.totalScore != null && (
-                <Text variant="small" style={{ fontFamily: "DMSans-Bold" }}>
+                <Text variant="small" style={{ fontWeight: "700", color: c.text }}>
                   {row.totalScore}/{row.maxScore ?? "?"}
                 </Text>
               )}
@@ -162,10 +163,11 @@ export function ResultsSegment({ filters }: Props) {
               }}
               style={({ pressed }) => [
                 styles.aiBtn,
+                { backgroundColor: ds.brandSoft },
                 pressed && { opacity: 0.7 },
               ]}
             >
-              <Ionicons name="sparkles" size={12} color="#4338CA" />
+              <Ionicons name="sparkles" size={12} color={c.primary} />
             </Pressable>
             <Ionicons
               name="chevron-forward"
@@ -193,7 +195,7 @@ export function ResultsSegment({ filters }: Props) {
             </View>
             <View style={styles.sheetHeader}>
               <View style={{ flex: 1 }}>
-                <Text variant="h3" style={{ fontFamily: "DMSans-Bold" }}>
+                <Text variant="h3" style={{ fontWeight: "700" }}>
                   AI-анализ
                 </Text>
                 {reportSession?.studentName && (
@@ -262,7 +264,6 @@ const styles = StyleSheet.create({
     width: 28,
     height: 28,
     borderRadius: 8,
-    backgroundColor: "#EEF2FF",
     alignItems: "center",
     justifyContent: "center",
   },


### PR DESCRIPTION
## Summary

Миграция Diagnostics-flow на DS-токены и façade-компоненты. ADR-019: только перекрашиваем, фичи не вырезаем.

**Затронуто 9 файлов:**
- `app/(tabs)/diagnostics.tsx` — 3 сегмента (Каталог/Назначения/Результаты)
- `app/(screens)/diagnostics/assign-class.tsx`
- `app/(screens)/diagnostics/assign-student.tsx`
- `app/(screens)/diagnostics/test/[slug].tsx`
- `components/diagnostics/CatalogSegment.tsx`
- `components/diagnostics/AssignmentsSegment.tsx`
- `components/diagnostics/ResultsSegment.tsx`
- `components/diagnostics/AiReportCard.tsx`
- `components/diagnostics/DiagnosticsFiltersSheet.tsx`

**Что сделано:**
- DMSans → Inter (через façade `typography.ts`)
- Хардкод HEX в `AiReportCard.tsx` (RISK_STYLES, RECOMMENDATION_META, header, error, flagged, tips) → DS-токены: `c.success/warning/danger/info/primary` + `ds.brandSoft/successSoft/warningSoft/dangerSoft/infoSoft`
- Submit-кнопки в assign-class/assign-student → `<Button variant="primary">`
- Footer-кнопки в test/[slug] → `<Button variant="primary">` + `<Button variant="secondary">`
- Apply/reset в DiagnosticsFiltersSheet → `<Button>`
- AssignmentsSegment: status-палитра (5 состояний) → DS-токены с `1A`/`33` прозрачностями
- ResultsSegment: AI-sparkles кнопка → `brandSoft`
- test/[slug] tips-card: жёлтый хардкод → `ds.warningSoft` + `c.warning`

**Что НЕ сделано (по issue):**
- `SegmentBtn` остаётся локальным (rule of three).
- Структура каталога/назначений/результатов не менялась.
- Новых тестов/метрик не добавлено.

## Test plan
- [ ] 3 сегмента переключаются.
- [ ] Каталог открывает деталь теста.
- [ ] Назначение классу работает (выбор класса/буквы/даты, отправка).
- [ ] Назначение ученику работает (поиск, выбор, отправка).
- [ ] Test/[slug] passing flow.
- [ ] AI-отчёт рендерится (loading/ready/error).
- [ ] Фильтры применяются и сбрасываются.
- [ ] Цвета согласованы с DS (теплая ленточка для warning, brand-teal для AI-блока).

## Notes
TypeScript: 19 pre-existing ошибок в `AiReportCard.tsx` (type-narrowing в `isReadyReport`/`isErrorReport`). Кол-во ошибок до/после миграции идентично — это **не регрессия**, а отдельная проблема, не входящая в скоуп DS-миграции (ADR-019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)