### PR TITLE
feat(ds): MessagesPage + DirectChat → DS façade (closes #59)

### DIFF
--- a/packages/psychologist-mobapp/app/(screens)/messages/[conversationId].tsx
+++ b/packages/psychologist-mobapp/app/(screens)/messages/[conversationId].tsx
@@ -2,7 +2,6 @@ import { useState, useRef, useEffect } from "react";
 import {
   View,
   FlatList,
-  TextInput,
   Pressable,
   KeyboardAvoidingView,
   Keyboard,
@@ -14,10 +13,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useT } from "../../../lib/hooks/useLanguage";
-import { Text } from "../../../components/ui";
+import { Text, Body, Input, Button } from "../../../components/ui";
 import { SkeletonList } from "../../../components/Skeleton";
-import { useThemeColors, spacing, radius } from "../../../lib/theme";
-import { shadow } from "../../../lib/theme/shadows";
+import { useThemeColors } from "../../../lib/theme";
+import { colors as ds } from "@tirek/shared/design-system";
 import { directChatApi } from "../../../lib/api/direct-chat";
 import { useAuthStore } from "../../../lib/store/auth-store";
 import { hapticLight } from "../../../lib/haptics";
@@ -121,7 +120,7 @@ export default function ChatScreen() {
           style={[
             styles.bubble,
             isMine
-              ? [styles.bubbleMine, { backgroundColor: c.primary }]
+              ? [styles.bubbleMine, { backgroundColor: ds.brandSoft }]
               : [
                   styles.bubbleOther,
                   { backgroundColor: c.surface, borderColor: c.borderLight },
@@ -132,7 +131,7 @@ export default function ChatScreen() {
             style={{
               fontSize: 14,
               lineHeight: 20,
-              color: isMine ? "#FFF" : c.text,
+              color: c.text,
             }}
           >
             {msg.content}
@@ -149,7 +148,7 @@ export default function ChatScreen() {
             <Text
               style={{
                 fontSize: 10,
-                color: isMine ? "rgba(255,255,255,0.6)" : c.textLight,
+                color: c.textLight,
               }}
             >
               {formatMessageTime(msg.createdAt)}
@@ -158,7 +157,7 @@ export default function ChatScreen() {
               <Ionicons
                 name={msg.readAt ? "checkmark-done" : "checkmark"}
                 size={12}
-                color={msg.readAt ? "#FFF" : "rgba(255,255,255,0.6)"}
+                color={msg.readAt ? c.primary : c.textLight}
               />
             )}
           </View>
@@ -184,14 +183,14 @@ export default function ChatScreen() {
           >
             <Ionicons name="arrow-back" size={22} color={c.text} />
           </Pressable>
-          <View style={[styles.headerAvatar, { backgroundColor: `${c.primary}1A` }]}>
-            <Text style={{ fontSize: 13, fontFamily: "DMSans-SemiBold", color: c.primary }}>
+          <View style={[styles.headerAvatar, { backgroundColor: ds.brandSoft }]}>
+            <Text style={{ fontSize: 13, fontWeight: "600", color: c.primary }}>
               {conversation?.otherUser?.name?.charAt(0)?.toUpperCase() ?? "?"}
             </Text>
           </View>
-          <Text variant="body" style={{ fontFamily: "DMSans-SemiBold", flex: 1 }} numberOfLines={1}>
+          <Body style={{ fontWeight: "600", flex: 1 }} numberOfLines={1}>
             {conversation?.otherUser?.name ?? t.directChat.title}
-          </Text>
+          </Body>
         </View>
 
         {/* Messages */}
@@ -221,37 +220,24 @@ export default function ChatScreen() {
             },
           ]}
         >
-          <TextInput
+          <Input
             value={input}
             onChangeText={setInput}
             placeholder={t.directChat.inputPlaceholder}
-            placeholderTextColor={c.textLight}
             multiline
             maxLength={2000}
-            style={[
-              styles.textInput,
-              {
-                backgroundColor: c.bg,
-                borderColor: c.borderLight,
-                color: c.text,
-              },
-            ]}
+            containerStyle={styles.inputContainer}
+            style={styles.inputText}
           />
-          <Pressable
+          <Button
+            title={t.directChat.send}
             onPress={handleSend}
             disabled={!input.trim() || sendMutation.isPending}
-            style={({ pressed }) => [
-              styles.sendButton,
-              { backgroundColor: c.primary },
-              (!input.trim() || sendMutation.isPending) && { opacity: 0.4 },
-              pressed && { opacity: 0.7 },
-            ]}
-          >
-            <Ionicons name="send" size={16} color="#FFF" />
-            <Text style={{ color: "#FFF", fontFamily: "DMSans-SemiBold", fontSize: 13 }}>
-              {t.directChat.send}
-            </Text>
-          </Pressable>
+            loading={sendMutation.isPending}
+            variant="primary"
+            size="sm"
+            fullWidth={false}
+          />
         </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -323,23 +309,12 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     borderTopWidth: 1,
   },
-  textInput: {
+  inputContainer: {
     flex: 1,
-    borderRadius: 18,
-    borderWidth: 1,
-    paddingHorizontal: 14,
-    paddingVertical: 10,
+  },
+  inputText: {
     fontSize: 14,
     maxHeight: 100,
-    fontFamily: "DMSans-Regular",
-  },
-  sendButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "center",
-    gap: 6,
-    height: 40,
-    paddingHorizontal: 14,
-    borderRadius: 12,
+    paddingVertical: 10,
   },
 });

--- a/packages/psychologist-mobapp/app/(tabs)/messages.tsx
+++ b/packages/psychologist-mobapp/app/(tabs)/messages.tsx
@@ -11,11 +11,11 @@ import { Ionicons } from "@expo/vector-icons";
 import { useRouter } from "expo-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useT } from "../../lib/hooks/useLanguage";
-import { Text, Input } from "../../components/ui";
+import { Text, Input, H3, Body, Card, Badge } from "../../components/ui";
 import { SkeletonList } from "../../components/Skeleton";
 import { ErrorState } from "../../components/ErrorState";
-import { useThemeColors, spacing, radius } from "../../lib/theme";
-import { shadow } from "../../lib/theme/shadows";
+import { useThemeColors } from "../../lib/theme";
+import { colors as ds } from "@tirek/shared/design-system";
 import { directChatApi } from "../../lib/api/direct-chat";
 import { hapticLight } from "../../lib/haptics";
 import type { Conversation } from "@tirek/shared";
@@ -80,7 +80,7 @@ export default function MessagesScreen() {
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.bg }]} edges={["top"]}>
       <View style={styles.header}>
-        <Text variant="h1">{t.directChat.title}</Text>
+        <H3>{t.directChat.title}</H3>
       </View>
 
       <View style={styles.searchRow}>
@@ -96,10 +96,10 @@ export default function MessagesScreen() {
         <SkeletonList count={4} />
       ) : filtered.length === 0 ? (
         <View style={styles.emptyState}>
-          <View style={[styles.emptyIcon, { backgroundColor: `${c.primary}1A` }]}>
+          <View style={[styles.emptyIcon, { backgroundColor: ds.brandSoft }]}>
             <Ionicons name="chatbubbles-outline" size={32} color={c.primary} />
           </View>
-          <Text variant="bodyLight">{t.directChat.noConversations}</Text>
+          <Body style={{ color: c.textLight }}>{t.directChat.noConversations}</Body>
         </View>
       ) : (
         <ScrollView
@@ -120,64 +120,47 @@ export default function MessagesScreen() {
                 router.push(`/(screens)/messages/${conv.id}`);
               }}
               style={({ pressed }) => [
-                styles.convCard,
-                {
-                  backgroundColor: c.surface,
-                  borderColor: c.borderLight,
-                },
-                shadow(1),
                 pressed && { opacity: 0.9, transform: [{ scale: 0.98 }] },
               ]}
             >
-              <View style={[styles.avatar, { backgroundColor: `${c.primary}1A` }]}>
-                <Text
-                  style={{
-                    fontSize: 15,
-                    fontFamily: "DMSans-SemiBold",
-                    color: c.primary,
-                  }}
-                >
-                  {conv.otherUser.name.charAt(0).toUpperCase()}
-                </Text>
-              </View>
-
-              <View style={styles.cardInfo}>
-                <View style={styles.nameRow}>
+              <Card style={styles.convCard}>
+                <View style={[styles.avatar, { backgroundColor: ds.brandSoft }]}>
                   <Text
-                    variant="body"
-                    style={{ fontFamily: "DMSans-SemiBold", flexShrink: 1 }}
-                    numberOfLines={1}
+                    style={{
+                      fontSize: 15,
+                      fontWeight: "600",
+                      color: c.primary,
+                    }}
                   >
-                    {conv.otherUser.name}
+                    {conv.otherUser.name.charAt(0).toUpperCase()}
                   </Text>
+                </View>
+
+                <View style={styles.cardInfo}>
+                  <View style={styles.nameRow}>
+                    <Body
+                      style={{ fontWeight: "600", flexShrink: 1 }}
+                      numberOfLines={1}
+                    >
+                      {conv.otherUser.name}
+                    </Body>
+                    {conv.lastMessage && (
+                      <Text variant="caption" style={{ flexShrink: 0 }}>
+                        {formatTime(conv.lastMessage.createdAt as string, t)}
+                      </Text>
+                    )}
+                  </View>
                   {conv.lastMessage && (
-                    <Text variant="caption" style={{ flexShrink: 0 }}>
-                      {formatTime(conv.lastMessage.createdAt as string, t)}
+                    <Text variant="bodyXs" numberOfLines={1} style={{ marginTop: 2, color: c.textLight }}>
+                      {conv.lastMessage.content}
                     </Text>
                   )}
                 </View>
-                {conv.lastMessage && (
-                  <Text variant="caption" numberOfLines={1} style={{ marginTop: 2 }}>
-                    {conv.lastMessage.content}
-                  </Text>
-                )}
-              </View>
 
-              {conv.unreadCount > 0 && (
-                <View style={[styles.unreadBadge, { backgroundColor: c.primary }]}>
-                  <Text
-                    style={{
-                      fontSize: 11,
-                      fontFamily: "DMSans-Bold",
-                      color: "#FFF",
-                    }}
-                  >
-                    {conv.unreadCount}
-                  </Text>
-                </View>
-              )}
+                <Badge count={conv.unreadCount} variant="primary" />
 
-              <Ionicons name="chevron-forward" size={16} color={`${c.textLight}60`} />
+                <Ionicons name="chevron-forward" size={16} color={`${c.textLight}60`} />
+              </Card>
             </Pressable>
           ))}
         </ScrollView>
@@ -209,8 +192,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 12,
     padding: 12,
-    borderRadius: radius.lg,
-    borderWidth: 1,
   },
   avatar: {
     width: 44,
@@ -228,14 +209,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "space-between",
     gap: 8,
-  },
-  unreadBadge: {
-    minWidth: 20,
-    height: 20,
-    borderRadius: 10,
-    paddingHorizontal: 6,
-    alignItems: "center",
-    justifyContent: "center",
   },
   emptyState: {
     flex: 1,


### PR DESCRIPTION
Миграция as-is по ADR-019: фичи не вырезаем, не добавляем, только перекрашиваем под DS-токены.

MessagesPage ((tabs)/messages.tsx):
- <Text variant="h1"> заголовка → <H3>.
- Conv-card: View+borderRadius+shadow → <Card>.
- Avatar tinted-фон с ${c.primary}1A → ds.brandSoft.
- Имя в карточке: variant=body + DMSans-SemiBold → <Body fontWeight 600>.
- Last-message preview: variant=caption → variant=bodyXs с textLight.
- Локальный unread badge → <Badge variant=primary> (DS-компонент с такой же семантикой).
- Empty-state иконка: ${c.primary}1A → ds.brandSoft, текст → <Body>.
- DMSans-SemiBold/DMSans-Bold → fontWeight 600/700 (Inter подхватится).

DirectChat ((screens)/messages/[conversationId].tsx):
- Bubble собственных сообщений: c.primary (заполненный teal с белым текстом) → ds.brandSoft с ink-цветом текста — по требованию issue #59 (--brand-soft для собственных). Визуальная регрессия намеренная.
- Read-receipts checkmark: цвет с белого/полупрозрачного → c.primary/c.textLight (после смены bubble-фона).
- Header avatar: ${c.primary}1A → ds.brandSoft.
- Header имя: variant=body + DMSans-SemiBold → <Body fontWeight 600>.
- TextInput input bar → <Input multiline>.
- Send-Pressable (custom layout с иконкой) → <Button size=sm variant=primary>. Иконка отправки убрана — Button показывает только title; компактнее, по DS.
- DMSans-* → fontWeight (Inter подхватится).

Не добавлены: typing indicator, read-receipts logic — по project_messages_model.
Не вырезано: pair-list, search, refresh, scroll-to-end, mark-read, KAV.