### PR TITLE
DS migration · psy-app web — semantic colors → DS tokens

### DIFF
--- a/packages/psychologist-app/src/components/diagnostics/AiReportCard.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/AiReportCard.tsx
@@ -31,9 +31,9 @@ interface AiReportCardProps {
 }
 
 const RISK_STYLES: Record<string, { bg: string; text: string; label: string }> = {
-  low: { bg: "bg-emerald-50", text: "text-emerald-700", label: "Низкий" },
-  moderate: { bg: "bg-amber-50", text: "text-amber-700", label: "Средний" },
-  high: { bg: "bg-red-50", text: "text-red-700", label: "Высокий" },
+  low: { bg: "bg-success/15", text: "text-success", label: "Низкий" },
+  moderate: { bg: "bg-warning/15", text: "text-warning", label: "Средний" },
+  high: { bg: "bg-danger/15", text: "text-danger", label: "Высокий" },
 };
 
 const RECOMMENDATION_META: Record<
@@ -137,19 +137,19 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
 
   if (isErrorReport(report)) {
     return (
-      <div className="rounded-2xl border border-red-200 bg-red-50/50 p-5">
-        <div className="flex items-center gap-2 text-red-700">
+      <div className="rounded-2xl border border-danger/30 bg-danger/10 p-5">
+        <div className="flex items-center gap-2 text-danger">
           <AlertCircle size={18} />
           <p className="text-sm font-bold">Не удалось сгенерировать отчёт</p>
         </div>
         {report.errorMessage && (
-          <p className="mt-2 text-xs text-red-600">{report.errorMessage}</p>
+          <p className="mt-2 text-xs text-danger">{report.errorMessage}</p>
         )}
         <button
           type="button"
           onClick={() => regenerate.mutate()}
           disabled={regenerate.isPending}
-          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-bold text-white hover:bg-red-700 disabled:opacity-60"
+          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-danger px-3 py-1.5 text-xs font-bold text-white hover:opacity-90 disabled:opacity-60"
         >
           {regenerate.isPending ? (
             <Loader2 size={14} className="animate-spin" />
@@ -200,7 +200,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
           type="button"
           onClick={() => regenerate.mutate()}
           disabled={regenerate.isPending}
-          className="inline-flex items-center gap-1 rounded-lg border border-border-light px-2 py-1 text-[11px] font-semibold text-text-light hover:bg-gray-50 disabled:opacity-60"
+          className="inline-flex items-center gap-1 rounded-lg border border-border-light px-2 py-1 text-[11px] font-semibold text-text-light hover:bg-surface-hover disabled:opacity-60"
           title="Перегенерировать"
         >
           {regenerate.isPending ? (
@@ -231,7 +231,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
 
       {/* Trend */}
       {report.trend && (
-        <div className="rounded-xl border border-border-light bg-gray-50 p-3">
+        <div className="rounded-xl border border-border-light bg-surface-secondary p-3">
           <div className="flex items-center gap-2">
             <LineChart size={14} className="text-text-light" />
             <p className="text-[11px] font-bold uppercase tracking-wider text-text-light">
@@ -322,8 +322,8 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
 
       {/* Flagged items */}
       {flaggedWithText.length > 0 && (
-        <details className="rounded-xl border border-amber-200 bg-amber-50/50 p-3">
-          <summary className="flex cursor-pointer items-center gap-2 text-sm font-bold text-amber-800">
+        <details className="rounded-xl border border-warning/30 bg-warning/10 p-3">
+          <summary className="flex cursor-pointer items-center gap-2 text-sm font-bold text-warning">
             <AlertTriangle size={14} />
             Тревожные ответы ({flaggedWithText.length})
           </summary>
@@ -331,7 +331,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
             {flaggedWithText.map((f, idx) => (
               <li
                 key={idx}
-                className="rounded-lg border border-amber-100 bg-white p-2.5"
+                className="rounded-lg border border-warning/20 bg-surface p-2.5"
               >
                 {f.questionText && (
                   <p className="text-xs font-semibold text-text-main">
@@ -341,7 +341,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
                 {(f.answerLabel || f.answerValue !== null) && (
                   <p className="mt-1 text-xs text-text-light">
                     Ответ:{" "}
-                    <span className="font-bold text-amber-700">
+                    <span className="font-bold text-warning">
                       {f.answerLabel ?? `значение ${f.answerValue}`}
                     </span>
                   </p>
@@ -358,7 +358,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
       )}
 
       {/* Disclaimer */}
-      <div className="flex items-start gap-2 rounded-lg bg-gray-50 p-2.5 text-[11px] text-text-light">
+      <div className="flex items-start gap-2 rounded-lg bg-surface-secondary p-2.5 text-[11px] text-text-light">
         <Info size={12} className="mt-0.5 shrink-0" />
         <p>
           Отчёт сформирован ИИ на основе ответов ученика и требует
@@ -401,13 +401,13 @@ function SkeletonReport() {
         </div>
       </div>
       <div className="space-y-2">
-        <div className="h-3 w-3/4 animate-pulse rounded bg-gray-200" />
-        <div className="h-3 w-full animate-pulse rounded bg-gray-200" />
-        <div className="h-3 w-5/6 animate-pulse rounded bg-gray-200" />
+        <div className="h-3 w-3/4 animate-pulse rounded bg-surface-hover" />
+        <div className="h-3 w-full animate-pulse rounded bg-surface-hover" />
+        <div className="h-3 w-5/6 animate-pulse rounded bg-surface-hover" />
       </div>
       <div className="space-y-2 pt-2">
-        <div className="h-10 animate-pulse rounded-xl bg-gray-100" />
-        <div className="h-10 animate-pulse rounded-xl bg-gray-100" />
+        <div className="h-10 animate-pulse rounded-xl bg-surface-secondary" />
+        <div className="h-10 animate-pulse rounded-xl bg-surface-secondary" />
       </div>
     </div>
   );

--- a/packages/psychologist-app/src/components/diagnostics/AssignmentsSegment.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/AssignmentsSegment.tsx
@@ -31,15 +31,15 @@ type Translations = {
 function statusColor(status: TestAssignmentStatus): string {
   switch (status) {
     case "pending":
-      return "bg-amber-50 text-amber-700 border-amber-200";
+      return "bg-warning/10 text-warning border-warning/30";
     case "in_progress":
-      return "bg-blue-50 text-blue-700 border-blue-200";
+      return "bg-info/15 text-info border-info/40";
     case "completed":
-      return "bg-green-50 text-green-700 border-green-200";
+      return "bg-success/15 text-success border-success/30";
     case "expired":
-      return "bg-gray-50 text-gray-500 border-gray-200";
+      return "bg-surface-secondary text-text-light border-border";
     case "cancelled":
-      return "bg-gray-50 text-gray-400 border-gray-200 line-through";
+      return "bg-surface-secondary text-text-light/70 border-border line-through";
   }
 }
 

--- a/packages/psychologist-app/src/components/student/MoodSparkline.tsx
+++ b/packages/psychologist-app/src/components/student/MoodSparkline.tsx
@@ -10,11 +10,11 @@ const moodEmojis: Record<number, string> = {
 };
 
 const dotColors: Record<number, string> = {
-  1: "#B33B3B",
-  2: "#8C6308",
-  3: "#CA8A04",
-  4: "#16794A",
-  5: "#059669",
+  1: "var(--danger)",
+  2: "var(--warning)",
+  3: "var(--warning)",
+  4: "var(--success)",
+  5: "var(--success)",
 };
 
 interface MoodSparklineProps {
@@ -78,8 +78,8 @@ export function MoodSparkline({ data, average, latestEntry }: MoodSparklineProps
       >
         <defs>
           <linearGradient id="sparkFill" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="#0F766E" stopOpacity="0.15" />
-            <stop offset="100%" stopColor="#0F766E" stopOpacity="0.02" />
+            <stop offset="0%" stopColor="var(--brand)" stopOpacity="0.15" />
+            <stop offset="100%" stopColor="var(--brand)" stopOpacity="0.02" />
           </linearGradient>
         </defs>
 
@@ -93,7 +93,7 @@ export function MoodSparkline({ data, average, latestEntry }: MoodSparklineProps
               x2={width - padX}
               y1={y}
               y2={y}
-              stroke="#D4DEDE"
+              stroke="var(--hairline)"
               strokeWidth="0.5"
               strokeDasharray="3,3"
             />
@@ -107,7 +107,7 @@ export function MoodSparkline({ data, average, latestEntry }: MoodSparklineProps
         <polyline
           points={polyline}
           fill="none"
-          stroke="#0F766E"
+          stroke="var(--brand)"
           strokeWidth="2"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -120,8 +120,8 @@ export function MoodSparkline({ data, average, latestEntry }: MoodSparklineProps
             cx={p.x}
             cy={p.y}
             r="3.5"
-            fill={dotColors[p.mood] ?? "#0F766E"}
-            stroke="#FFFFFF"
+            fill={dotColors[p.mood] ?? "var(--brand)"}
+            stroke="var(--surface)"
             strokeWidth="1.5"
           />
         ))}

--- a/packages/psychologist-app/src/components/ui/SeverityBadge.tsx
+++ b/packages/psychologist-app/src/components/ui/SeverityBadge.tsx
@@ -9,7 +9,7 @@ interface SeverityBadgeProps {
 const styles: Record<string, { bg: string; text: string }> = {
   minimal: { bg: "bg-success/15", text: "text-success" },
   mild: { bg: "bg-warning/15", text: "text-warning" },
-  moderate: { bg: "bg-orange-100", text: "text-orange-600" },
+  moderate: { bg: "bg-warning/15", text: "text-warning" },
   severe: { bg: "bg-danger/15", text: "text-danger" },
 };
 

--- a/packages/psychologist-app/src/pages/AssignToStudentPage.tsx
+++ b/packages/psychologist-app/src/pages/AssignToStudentPage.tsx
@@ -139,7 +139,7 @@ export function AssignToStudentPage() {
                 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
             />
           </div>
-          <div className="max-h-72 overflow-y-auto border border-border rounded-lg divide-y divide-gray-50">
+          <div className="max-h-72 overflow-y-auto border border-border rounded-lg divide-y divide-border-light">
             {filteredStudents.map((s) => (
               <button
                 key={s.id}

--- a/packages/psychologist-app/src/pages/CrisisPage.tsx
+++ b/packages/psychologist-app/src/pages/CrisisPage.tsx
@@ -216,7 +216,7 @@ export function CrisisPage() {
             <span
               className={clsx(
                 "w-2 h-2 rounded-full",
-                !isRed ? "bg-yellow-400" : "bg-yellow-400/50",
+                !isRed ? "bg-warning" : "bg-warning/50",
               )}
             />
             {t.psychologist.yellowFeed}
@@ -225,8 +225,8 @@ export function CrisisPage() {
                 className={clsx(
                   "px-1.5 py-0.5 text-[10px] font-bold rounded-full",
                   !isRed
-                    ? "bg-yellow-400 text-white"
-                    : "bg-yellow-400/10 text-yellow-600",
+                    ? "bg-warning text-white"
+                    : "bg-warning/10 text-warning",
                 )}
               >
                 {yellowSignals.length}
@@ -264,7 +264,7 @@ export function CrisisPage() {
                           "w-10 h-10 rounded-full flex items-center justify-center shrink-0 text-sm font-bold",
                           isRed
                             ? "bg-danger/10 text-danger"
-                            : "bg-yellow-400/10 text-yellow-600",
+                            : "bg-warning/10 text-warning",
                         )}
                       >
                         {signal.studentName.charAt(0).toUpperCase()}
@@ -297,7 +297,7 @@ export function CrisisPage() {
                               ? "bg-danger text-white"
                               : "bg-warning text-white"),
                           signal.severity === "medium" &&
-                            "bg-yellow-400 text-white",
+                            "bg-warning text-white",
                           signal.severity === "low" &&
                             "bg-surface-secondary text-text-light",
                         )}
@@ -312,7 +312,7 @@ export function CrisisPage() {
                         "mb-3 rounded-xl px-3 py-2.5 border",
                         isRed
                           ? "bg-danger/5 border-danger/10"
-                          : "bg-yellow-400/5 border-yellow-400/15",
+                          : "bg-warning/5 border-warning/15",
                       )}
                     >
                       <p className="text-[13px] text-text-main leading-relaxed">
@@ -464,7 +464,7 @@ export function CrisisPage() {
                                 "px-1.5 py-0.5 text-[10px] font-bold rounded-md",
                                 signal.type === "acute_crisis"
                                   ? "bg-danger/10 text-danger"
-                                  : "bg-yellow-400/10 text-yellow-600",
+                                  : "bg-warning/10 text-warning",
                               )}
                             >
                               {signal.type === "acute_crisis"
@@ -611,7 +611,7 @@ export function CrisisPage() {
                       "w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold",
                       resolveSignal.type === "acute_crisis"
                         ? "bg-danger/10 text-danger"
-                        : "bg-yellow-400/10 text-yellow-600",
+                        : "bg-warning/10 text-warning",
                     )}
                   >
                     {resolveSignal.studentName.charAt(0).toUpperCase()}

--- a/packages/psychologist-app/src/pages/OnboardingPage.tsx
+++ b/packages/psychologist-app/src/pages/OnboardingPage.tsx
@@ -25,64 +25,25 @@ interface OnboardingStep {
   accentColor: string;
 }
 
+const BRAND_GRADIENT = "from-primary to-primary-dark";
+const BRAND_ACCENT = "bg-primary";
+
 const STEP_STYLES: OnboardingStep[] = [
-  {
-    icon: LayoutDashboard,
-    gradient: "from-teal-500 to-emerald-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-teal-500",
-  },
-  {
-    icon: Users,
-    gradient: "from-blue-500 to-cyan-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-blue-500",
-  },
-  {
-    icon: AlertTriangle,
-    gradient: "from-red-500 to-rose-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-red-500",
-  },
-  {
-    icon: MessageSquare,
-    gradient: "from-violet-500 to-purple-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-violet-500",
-  },
-  {
-    icon: ClipboardList,
-    gradient: "from-amber-500 to-orange-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-amber-500",
-  },
-  {
-    icon: Calendar,
-    gradient: "from-emerald-500 to-green-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-emerald-500",
-  },
-  {
-    icon: KeyRound,
-    gradient: "from-pink-500 to-fuchsia-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-pink-500",
-  },
-  {
-    icon: BarChart3,
-    gradient: "from-indigo-500 to-blue-500",
-    iconBg: "bg-white/20",
-    iconColor: "text-white",
-    accentColor: "bg-indigo-500",
-  },
-];
+  LayoutDashboard,
+  Users,
+  AlertTriangle,
+  MessageSquare,
+  ClipboardList,
+  Calendar,
+  KeyRound,
+  BarChart3,
+].map((icon) => ({
+  icon,
+  gradient: BRAND_GRADIENT,
+  iconBg: "bg-white/20",
+  iconColor: "text-white",
+  accentColor: BRAND_ACCENT,
+}));
 
 export function OnboardingPage({ onComplete }: { onComplete: () => void }) {
   const t = useT();
@@ -131,7 +92,7 @@ export function OnboardingPage({ onComplete }: { onComplete: () => void }) {
         <div className="w-full max-w-sm animate-fade-in-up">
           {/* Logo area */}
           <div className="flex justify-center mb-8">
-            <div className="w-20 h-20 rounded-3xl bg-gradient-to-br from-teal-500 to-emerald-600 flex items-center justify-center shadow-lg glow-primary">
+            <div className="w-20 h-20 rounded-3xl bg-gradient-to-br from-primary to-primary-dark flex items-center justify-center shadow-lg glow-primary">
               <Sparkles size={36} className="text-white" />
             </div>
           </div>

--- a/packages/psychologist-app/src/pages/ProfilePage.tsx
+++ b/packages/psychologist-app/src/pages/ProfilePage.tsx
@@ -168,7 +168,7 @@ export function ProfilePage() {
                 "flex items-center gap-2 px-4 py-2.5 rounded-lg border-2 text-sm font-medium transition-colors",
                 language === lang.code
                   ? "border-primary bg-primary/5 text-primary"
-                  : "border-border text-text-light hover:border-gray-300",
+                  : "border-border text-text-light hover:border-text-light/40",
               )}
             >
               {language === lang.code && <Check size={14} />}

--- a/packages/psychologist-app/src/pages/TestDetailPage.tsx
+++ b/packages/psychologist-app/src/pages/TestDetailPage.tsx
@@ -75,14 +75,14 @@ export function TestDetailPage() {
       </div>
 
       {tips && (
-        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+        <div className="rounded-xl border border-warning/30 bg-warning/10 p-4">
           <div className="flex items-center gap-2 mb-2">
-            <Lightbulb size={16} className="text-amber-600" />
-            <span className="text-sm font-bold text-amber-900">
+            <Lightbulb size={16} className="text-warning" />
+            <span className="text-sm font-bold text-text-main">
               {t.psychologist.testWhenToAssign}
             </span>
           </div>
-          <p className="text-sm leading-relaxed text-amber-900">{tips}</p>
+          <p className="text-sm leading-relaxed text-text-main">{tips}</p>
         </div>
       )}
 


### PR DESCRIPTION
Closes #61. Parent: #49.

## Summary

- Hardcoded семантические цвета (`bg-yellow-400`, `bg-amber-*`, `bg-red-*`, `bg-orange-*`, `bg-emerald-*`) → DS-токены (`bg-warning`, `bg-danger`, `bg-success`) через Tailwind v4 `@theme` (ADR-011).
- Hex-литералы в `MoodSparkline.tsx` (`#0F766E`, `#D4DEDE`, `#B33B3B`, `#8C6308`, `#16794A`, `#059669`, `#FFFFFF`) → CSS-переменные DS (`var(--brand)`, `var(--hairline)`, `var(--danger)`, `var(--warning)`, `var(--success)`, `var(--surface)`).
- `OnboardingPage`: 8 разноцветных gradient/accent → единый `bg-primary` / `from-primary to-primary-dark` (ADR-005 «Tirek-расширения» / ADR-019).
- Нейтралы `gray-*`/`bg-gray-50/100/200` → `surface-secondary`/`surface-hover`/`border-light`/`text-light/40`.

## Затронутые файлы

| Файл | Что |
|------|-----|
| `MoodSparkline.tsx` | hex → токены, dot-цвета по mood1-5 на danger/warning/success |
| `OnboardingPage.tsx` | 8 цветов → brand |
| `CrisisPage.tsx` | `bg-yellow-400/X` → `bg-warning/X` (ADR-003 живой `#FFB319`) |
| `AssignmentsSegment.tsx` | status badges (pending/in_progress/completed/expired/cancelled) → DS |
| `SeverityBadge.tsx` | `moderate: orange-100/600` → `warning/15+text-warning` |
| `TestDetailPage.tsx` | tips amber → warning |
| `AiReportCard.tsx` | RISK_STYLES (low/moderate/high) → success/warning/danger; error-карточка → danger; «Тревожные ответы» → warning; gray-нейтралы → surface |
| `AssignToStudentPage.tsx` | `divide-gray-50` → `divide-border-light` |
| `ProfilePage.tsx` | `hover:border-gray-300` → `hover:border-text-light/40` |

## Что НЕ менялось (намеренно)

По ADR-019 «не вырезать молча, не менять то, что не семантично»:

- **AI-бренд** в `AiReportCard.tsx` (`from-violet-100 to-indigo-100`, `text-indigo-600/700`, `bg-blue-50`, `bg-teal-50`, `bg-purple-50`, `bg-slate-50`, `bg-indigo-50`) — это категориальный визуальный язык AI-отчёта (рекомендации: therapy/exercise/referral/monitoring/conversation), не сигналы DS.
- **CBT-тег violet** в `StudentOverviewTab.tsx`/`StudentAssessmentsTab.tsx` (`bg-violet-100 text-violet-700`) — категориальная метка вида практики «дневник мыслей».
- **Achievement amber** (`text-amber-600`, `border-amber-200 bg-amber-50/50`) — категориальный «золотая медаль» эффект для earned achievements.
- **`glass-card`/`glow-primary`/`pulse-border`** в `index.css` — уже переписаны через `var(--brand)`/`var(--brand-soft)`/`var(--danger)` в #50, отдельных правок не потребовалось.
- **`<MoodScale>`** в `StudentsListPage.tsx` — уже подключён в #55.

## Visual changes after migration

- Yellow-feed (CrisisPage) станет ярче: охра → живой `#FFB319` (ADR-003).
- Severity `moderate` (умеренный риск) поменяет оттенок с orange на warning yellow.
- AssignmentsSegment status-чипы подровнены под DS-семантику: pending — warning, in_progress — info, completed — success.
- AiReportCard: error-карточка станет ярче (живой `#FF4E64` вместо `red-600`); risk «Высокий» — `#FF4E64`, «Средний» — `#FFB319`, «Низкий» — `#16794A`.
- Onboarding: 8 разноцветных шагов теперь единого brand-teal цвета — мономорфный, без визуального шума.

## Test plan

- [x] `pnpm tsc --noEmit` — green
- [x] `pnpm build` — green (4.05s, без ошибок)
- [ ] Визуально проверить: CrisisPage (yellow-feed), DiagnosticsPage Assignments tab, OnboardingPage (8 шагов), Test Detail (tips), Student Profile (Assessments → AI Report), AssignToStudent

🤖 Generated with [Claude Code](https://claude.com/claude-code)