### PR TITLE
feat(redesign): DS arsenal — Stepper, Tooltip, HelpSheet (closes #74)

### DIFF
--- a/packages/psychologist-app/src/components/ui/Stepper.tsx
+++ b/packages/psychologist-app/src/components/ui/Stepper.tsx
@@ -1,0 +1,79 @@
+import { Check } from "lucide-react";
+import { clsx } from "clsx";
+
+export interface StepperStep {
+  id: string;
+  label: string;
+}
+
+interface StepperProps {
+  steps: StepperStep[];
+  /** Index of the active step (0-based). */
+  current: number;
+  /** Allow clicking already-completed steps to navigate back. */
+  onStepClick?: (index: number) => void;
+}
+
+export function Stepper({ steps, current, onStepClick }: StepperProps) {
+  return (
+    <ol className="flex items-center w-full" aria-label="Steps">
+      {steps.map((step, idx) => {
+        const isDone = idx < current;
+        const isActive = idx === current;
+        const clickable = !!onStepClick && isDone;
+
+        const circle = (
+          <span
+            className={clsx(
+              "relative z-[1] w-8 h-8 rounded-full flex items-center justify-center text-[12px] font-bold border-2 transition-colors",
+              isDone && "bg-brand text-white border-brand",
+              isActive && "bg-surface text-brand border-brand",
+              !isDone && !isActive && "bg-surface text-ink-muted border-border",
+            )}
+          >
+            {isDone ? <Check size={14} strokeWidth={3} /> : idx + 1}
+          </span>
+        );
+
+        return (
+          <li
+            key={step.id}
+            className={clsx("flex items-center", idx < steps.length - 1 && "flex-1")}
+          >
+            <div className="flex flex-col items-center min-w-0">
+              {clickable ? (
+                <button
+                  type="button"
+                  onClick={() => onStepClick(idx)}
+                  className="cursor-pointer"
+                  aria-label={`Go to step ${idx + 1}: ${step.label}`}
+                >
+                  {circle}
+                </button>
+              ) : (
+                circle
+              )}
+              <span
+                className={clsx(
+                  "mt-1.5 text-[11px] font-semibold truncate max-w-[90px] text-center",
+                  isActive ? "text-ink" : "text-ink-muted",
+                )}
+              >
+                {step.label}
+              </span>
+            </div>
+            {idx < steps.length - 1 && (
+              <div
+                className={clsx(
+                  "flex-1 h-px mx-2 -mt-5",
+                  isDone ? "bg-brand" : "bg-border",
+                )}
+                aria-hidden
+              />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/packages/psychologist-app/src/components/ui/Tooltip.tsx
+++ b/packages/psychologist-app/src/components/ui/Tooltip.tsx
@@ -1,0 +1,53 @@
+import { useState, type ReactNode } from "react";
+import { clsx } from "clsx";
+
+interface TooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+  /** Default: top. */
+  side?: "top" | "bottom";
+  /** Delay before showing in ms. Default 200. */
+  delay?: number;
+}
+
+export function Tooltip({ content, children, side = "top", delay = 200 }: TooltipProps) {
+  const [open, setOpen] = useState(false);
+  const [timer, setTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleEnter = () => {
+    if (timer) clearTimeout(timer);
+    setTimer(setTimeout(() => setOpen(true), delay));
+  };
+  const handleLeave = () => {
+    if (timer) {
+      clearTimeout(timer);
+      setTimer(null);
+    }
+    setOpen(false);
+  };
+
+  return (
+    <span
+      className="relative inline-flex"
+      onMouseEnter={handleEnter}
+      onMouseLeave={handleLeave}
+      onFocus={handleEnter}
+      onBlur={handleLeave}
+    >
+      {children}
+      {open && (
+        <span
+          role="tooltip"
+          className={clsx(
+            "pointer-events-none absolute left-1/2 -translate-x-1/2 z-50",
+            "px-2.5 py-1.5 rounded-lg bg-ink text-white text-[11px] font-medium whitespace-nowrap",
+            "shadow-lg",
+            side === "top" ? "bottom-full mb-1.5" : "top-full mt-1.5",
+          )}
+        >
+          {content}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/psychologist-app/src/pages/DesignSystemDevPage.tsx
+++ b/packages/psychologist-app/src/pages/DesignSystemDevPage.tsx
@@ -1,7 +1,11 @@
+import { useState } from "react";
 import type { MoodEntry } from "@tirek/shared";
+import { Info } from "lucide-react";
 import { DataTable, type DataTableColumn } from "../components/ui/DataTable.js";
 import { MoodChart } from "../components/student/MoodChart.js";
 import { StatusBadge } from "../components/ui/StatusBadge.js";
+import { Stepper } from "../components/ui/Stepper.js";
+import { Tooltip } from "../components/ui/Tooltip.js";
 
 interface DemoStudent {
   id: string;
@@ -60,6 +64,13 @@ const moodData14 = Array.from({ length: 14 }, (_, i) => ({
 }));
 
 export function DesignSystemDevPage() {
+  const [stepperCurrent, setStepperCurrent] = useState(1);
+  const stepperSteps = [
+    { id: "test", label: "Тест" },
+    { id: "target", label: "Получатель" },
+    { id: "confirm", label: "Подтвердить" },
+  ];
+
   return (
     <div className="max-w-6xl mx-auto p-6 space-y-12">
       <header>
@@ -111,6 +122,55 @@ export function DesignSystemDevPage() {
         <h2 className="text-lg font-semibold text-text-main">MoodChart · size="inline"</h2>
         <div className="max-w-md">
           <MoodChart data={moodData14.slice(-7)} average={3.4} />
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-text-main">Stepper</h2>
+        <div className="max-w-md space-y-3">
+          <Stepper
+            steps={stepperSteps}
+            current={stepperCurrent}
+            onStepClick={setStepperCurrent}
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() =>
+                setStepperCurrent((s) => Math.max(0, s - 1))
+              }
+              className="px-3 py-1.5 text-xs rounded-lg border border-border bg-surface hover:bg-surface-hover"
+            >
+              ← prev
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setStepperCurrent((s) => Math.min(stepperSteps.length - 1, s + 1))
+              }
+              className="px-3 py-1.5 text-xs rounded-lg border border-border bg-surface hover:bg-surface-hover"
+            >
+              next →
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold text-text-main">Tooltip</h2>
+        <div className="flex items-center gap-3">
+          <Tooltip content="PHQ-9 — стандартный скрининг депрессии (9 вопросов)">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg bg-surface border border-border text-sm text-ink-muted hover:text-ink"
+            >
+              <Info size={14} />
+              Hover me
+            </button>
+          </Tooltip>
+          <Tooltip content="Подсказка снизу" side="bottom">
+            <span className="text-sm underline cursor-help">подсказка снизу</span>
+          </Tooltip>
         </div>
       </section>
 

--- a/packages/psychologist-mobapp/components/ui/HelpSheet.tsx
+++ b/packages/psychologist-mobapp/components/ui/HelpSheet.tsx
@@ -1,0 +1,136 @@
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  type ViewProps,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { H3, Body } from "./Typography";
+import { useThemeColors, radius, spacing } from "../../lib/theme";
+
+interface HelpSheetProps extends ViewProps {
+  visible: boolean;
+  title: string;
+  /** Optional richer body. If only string is needed pass `description`. */
+  description?: string;
+  onClose: () => void;
+  children?: React.ReactNode;
+}
+
+/**
+ * Bottom-sheet for explanatory help (test descriptions, "how does X work").
+ * Distinct from `<Sheet>` (layout primitive) — this one is a self-contained
+ * modal you summon from "?"-style buttons.
+ */
+export function HelpSheet({
+  visible,
+  title,
+  description,
+  onClose,
+  children,
+  style,
+}: HelpSheetProps) {
+  const c = useThemeColors();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onClose}
+        accessibilityLabel="Close help"
+      />
+      <View
+        style={[
+          styles.sheet,
+          { backgroundColor: c.surface },
+          style,
+        ]}
+      >
+        <View style={styles.handle}>
+          <View style={[styles.handleBar, { backgroundColor: c.border }]} />
+        </View>
+
+        <View style={styles.header}>
+          <H3 style={{ flex: 1 }}>{title}</H3>
+          <Pressable
+            onPress={onClose}
+            style={({ pressed }) => [
+              styles.closeBtn,
+              { backgroundColor: c.surfaceSecondary },
+              pressed && { opacity: 0.7 },
+            ]}
+            accessibilityLabel="Close"
+          >
+            <Ionicons name="close" size={18} color={c.textLight} />
+          </Pressable>
+        </View>
+
+        <ScrollView
+          style={styles.body}
+          contentContainerStyle={styles.bodyContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {description && (
+            <Body style={{ lineHeight: 22 }}>{description}</Body>
+          )}
+          {children}
+        </ScrollView>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.4)",
+  },
+  sheet: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderTopLeftRadius: radius["3xl"],
+    borderTopRightRadius: radius["3xl"],
+    maxHeight: "85%",
+    paddingBottom: spacing["3xl"],
+  },
+  handle: {
+    alignItems: "center",
+    paddingTop: 10,
+    paddingBottom: 4,
+  },
+  handleBar: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    paddingHorizontal: spacing.xl,
+  },
+  bodyContent: {
+    paddingBottom: spacing.xl,
+  },
+});

--- a/packages/psychologist-mobapp/components/ui/Stepper.tsx
+++ b/packages/psychologist-mobapp/components/ui/Stepper.tsx
@@ -1,0 +1,114 @@
+import { View, StyleSheet } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { Text } from "./Text";
+import { useThemeColors } from "../../lib/theme";
+
+export interface StepperStep {
+  id: string;
+  label: string;
+}
+
+interface StepperProps {
+  steps: StepperStep[];
+  /** Index of the active step (0-based). */
+  current: number;
+}
+
+export function Stepper({ steps, current }: StepperProps) {
+  const c = useThemeColors();
+
+  return (
+    <View style={styles.row}>
+      {steps.map((step, idx) => {
+        const isDone = idx < current;
+        const isActive = idx === current;
+        const circleBg = isDone ? c.primary : c.surface;
+        const circleBorder = isDone || isActive ? c.primary : c.border;
+        const numberColor = isDone ? "#FFFFFF" : isActive ? c.primary : c.textLight;
+        const labelColor = isActive ? c.text : c.textLight;
+        const lineColor = isDone ? c.primary : c.border;
+
+        return (
+          <View
+            key={step.id}
+            style={[
+              styles.stepWrap,
+              idx < steps.length - 1 && { flex: 1 },
+            ]}
+          >
+            <View style={styles.itemColumn}>
+              <View
+                style={[
+                  styles.circle,
+                  { backgroundColor: circleBg, borderColor: circleBorder },
+                ]}
+              >
+                {isDone ? (
+                  <Ionicons name="checkmark" size={16} color="#FFFFFF" />
+                ) : (
+                  <Text
+                    style={[styles.number, { color: numberColor }]}
+                  >
+                    {idx + 1}
+                  </Text>
+                )}
+              </View>
+              <Text
+                variant="caption"
+                style={[styles.label, { color: labelColor }]}
+                numberOfLines={1}
+              >
+                {step.label}
+              </Text>
+            </View>
+            {idx < steps.length - 1 && (
+              <View
+                style={[styles.line, { backgroundColor: lineColor }]}
+              />
+            )}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    width: "100%",
+  },
+  stepWrap: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+  },
+  itemColumn: {
+    alignItems: "center",
+    width: 80,
+  },
+  circle: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    borderWidth: 2,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  number: {
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  label: {
+    marginTop: 4,
+    fontSize: 11,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  line: {
+    flex: 1,
+    height: 1,
+    marginTop: 14,
+    marginHorizontal: 2,
+  },
+});

--- a/packages/psychologist-mobapp/components/ui/index.ts
+++ b/packages/psychologist-mobapp/components/ui/index.ts
@@ -14,3 +14,6 @@ export { EmptyState } from "./EmptyState";
 export type { EmptyStateVariant } from "./EmptyState";
 export { HorizontalScrollList } from "./HorizontalScrollList";
 export { DayDivider } from "./DayDivider";
+export { Stepper } from "./Stepper";
+export type { StepperStep } from "./Stepper";
+export { HelpSheet } from "./HelpSheet";


### PR DESCRIPTION
## Summary
Закрывает #74. Добавлены недостающие компоненты в DS-арсенал:

**Web (psy-app):**
- `Stepper` — горизонтальный индикатор шагов с галочкой done и click-back
- `Tooltip` — hover-подсказка над/под триггером

**Mobile (psy-mobapp):**
- `Stepper` — RN-эквивалент
- `HelpSheet` — bottom-sheet модалка для пояснений (UI-примитив, отличается от `Sheet` для layout)

`DesignSystemDevPage` обновлён с демо новых компонентов.

## Что НЕ добавлено и почему
- DataTable, Sidebar, MoodChart, DayDivider, EmptyState, HorizontalScrollList — добавлены в #79..#82
- Toast — `sonner` Toaster уже подключён в `App.tsx`, отдельный компонент не нужен

## Test plan
- [ ] DS dev-page (`/dev/ds`) рендерит Stepper и Tooltip корректно
- [ ] Stepper: prev/next кнопки переключают current; click по done-шагу возвращает назад
- [ ] Tooltip: hover/focus показывает контент через 200ms; mouseleave скрывает
- [ ] Mobile: Stepper показывает 3 шага, HelpSheet открывается из триггера, закрывается X-кнопкой и backdrop tap
- [ ] `vite build` зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)