### PR TITLE
feat(redesign): эпик #89 · post-#73 — детальные экраны и UI-кусочки

### DIFF
--- a/packages/psychologist-app/src/components/diagnostics/AiReportCard.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/AiReportCard.tsx
@@ -38,37 +38,27 @@ const RISK_STYLES: Record<string, { bg: string; text: string; label: string }> =
 
 const RECOMMENDATION_META: Record<
   AiReportRecommendationType,
-  { icon: typeof Stethoscope; label: string; bg: string; color: string }
+  { icon: typeof Stethoscope; label: string }
 > = {
   therapy: {
     icon: Users,
     label: "Индивидуальная беседа",
-    bg: "bg-blue-50",
-    color: "text-blue-700",
   },
   exercise: {
     icon: Wind,
     label: "Упражнение",
-    bg: "bg-teal-50",
-    color: "text-teal-700",
   },
   referral: {
     icon: Stethoscope,
     label: "Направление",
-    bg: "bg-purple-50",
-    color: "text-purple-700",
   },
   monitoring: {
     icon: LineChart,
     label: "Наблюдение",
-    bg: "bg-slate-50",
-    color: "text-slate-700",
   },
   conversation: {
     icon: Users,
     label: "Разговор",
-    bg: "bg-indigo-50",
-    color: "text-indigo-700",
   },
 };
 
@@ -90,7 +80,6 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
   const { data: report, isLoading } = useQuery({
     queryKey: ["diagnostics", "report", sessionId],
     queryFn: () => getReport(sessionId),
-    // Poll while the report is still being generated.
     refetchInterval: (q) => {
       const d = q.state.data;
       if (!d) return 3000;
@@ -129,7 +118,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
 
   if (isLoading || !report) {
     return (
-      <div className="rounded-2xl border border-border-light bg-white p-5">
+      <div className="rounded-2xl border border-border-light bg-surface p-5">
         <SkeletonReport />
       </div>
     );
@@ -163,24 +152,23 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
   }
 
   if (!isReadyReport(report)) {
-    // pending
     return (
-      <div className="rounded-2xl border border-border-light bg-white p-5">
+      <div className="rounded-2xl border border-border-light bg-surface p-5">
         <SkeletonReport />
       </div>
     );
   }
 
   return (
-    <div className="space-y-4 rounded-2xl border border-border-light bg-white p-5">
-      {/* Header */}
+    <div className="space-y-4 rounded-2xl border border-border-light bg-surface p-5">
+      {/* Header — neutral surface with brand-soft accent */}
       <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-violet-100 to-indigo-100">
-            <Bot size={18} className="text-indigo-600" />
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-soft">
+            <Bot size={18} className="text-brand-deep" />
           </div>
           <div>
-            <p className="text-xs font-bold uppercase tracking-wider text-indigo-700">
+            <p className="text-[11px] font-bold uppercase tracking-wider text-brand-deep">
               AI-анализ результата
             </p>
             {report.generatedAt && (
@@ -212,9 +200,9 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
         </button>
       </div>
 
-      {/* Summary */}
+      {/* Summary — most important, larger */}
       {report.summary && (
-        <p className="text-sm font-bold leading-snug text-text-main">
+        <p className="text-base font-semibold leading-snug text-text-main">
           {report.summary}
         </p>
       )}
@@ -238,7 +226,7 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
               Динамика
             </p>
           </div>
-          <p className="mt-1 text-xs text-text-main">{report.trend}</p>
+          <p className="mt-1 text-sm text-text-main">{report.trend}</p>
         </div>
       )}
 
@@ -294,21 +282,11 @@ export function AiReportCard({ sessionId }: AiReportCardProps) {
                   key={idx}
                   className="flex gap-3 rounded-xl border border-border-light p-3"
                 >
-                  <div
-                    className={clsx(
-                      "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg",
-                      meta.bg,
-                    )}
-                  >
-                    <Icon size={16} className={meta.color} />
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-secondary">
+                    <Icon size={16} className="text-text-light" />
                   </div>
                   <div className="flex-1">
-                    <p
-                      className={clsx(
-                        "text-[10px] font-bold uppercase tracking-wider",
-                        meta.color,
-                      )}
-                    >
+                    <p className="text-[10px] font-bold uppercase tracking-wider text-text-light">
                       {meta.label}
                     </p>
                     <p className="mt-0.5 text-sm text-text-main">{r.text}</p>
@@ -389,12 +367,12 @@ function SectionTitle({
 function SkeletonReport() {
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-violet-100 to-indigo-100">
-          <Loader2 size={18} className="animate-spin text-indigo-600" />
+      <div className="flex items-center gap-2.5">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-brand-soft">
+          <Loader2 size={18} className="animate-spin text-brand-deep" />
         </div>
         <div>
-          <p className="text-xs font-bold uppercase tracking-wider text-indigo-700">
+          <p className="text-[11px] font-bold uppercase tracking-wider text-brand-deep">
             AI-анализ результата
           </p>
           <p className="text-[11px] text-text-light">Генерируется…</p>

--- a/packages/psychologist-app/src/components/diagnostics/AssignmentsSegment.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/AssignmentsSegment.tsx
@@ -11,6 +11,7 @@ import {
   type TestAssignmentStatus,
 } from "../../api/diagnostics.js";
 import { useT, useLanguage } from "../../hooks/useLanguage.js";
+import { DataTable, type DataTableColumn } from "../ui/DataTable.js";
 
 const STATUSES: { key: TestAssignmentStatus; labelKey: keyof Translations }[] = [
   { key: "pending", labelKey: "assignmentStatusPending" },
@@ -89,38 +90,104 @@ export function AssignmentsSegment() {
     cancelMutation.mutate(id);
   }
 
+  const columns: DataTableColumn<TestAssignmentRow>[] = [
+    {
+      key: "target",
+      header: t.psychologist.assignSelectStudent,
+      width: "26%",
+      cell: (row) => (
+        <span className="font-semibold text-text-main truncate block">
+          {targetLabel(row)}
+        </span>
+      ),
+    },
+    {
+      key: "test",
+      header: t.psychologist.diagnostics,
+      cell: (row) => (
+        <span className="text-text-light text-sm truncate block">
+          {testNameForRow(row)}
+        </span>
+      ),
+      hideOnSmall: true,
+    },
+    {
+      key: "status",
+      header: "",
+      width: "140px",
+      cell: (row) => (
+        <span
+          className={clsx(
+            "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border whitespace-nowrap",
+            statusColor(row.status),
+          )}
+        >
+          {(t.psychologist as unknown as Translations)[
+            STATUSES.find((s) => s.key === row.status)?.labelKey ??
+              "assignmentStatusPending"
+          ]}
+        </span>
+      ),
+    },
+    {
+      key: "due",
+      header: t.psychologist.assignmentDueDate,
+      width: "110px",
+      hideOnSmall: true,
+      cell: (row) =>
+        row.dueDate ? (
+          <span className="inline-flex items-center gap-1 text-xs text-text-light tabular-nums">
+            <Calendar size={11} />
+            {new Date(row.dueDate).toLocaleDateString()}
+          </span>
+        ) : (
+          <span className="text-xs text-text-light">—</span>
+        ),
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      width: "100px",
+      cell: (row) => {
+        const canCancel =
+          row.status === "pending" || row.status === "in_progress";
+        if (!canCancel) return null;
+        return (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleCancel(row.id);
+            }}
+            disabled={cancelMutation.isPending}
+            className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md border border-border text-[11px] font-semibold text-text-light hover:bg-surface-hover disabled:opacity-50"
+          >
+            {t.psychologist.cancelAssignment}
+          </button>
+        );
+      },
+    },
+  ];
+
   return (
     <div className="space-y-3">
       <div className="overflow-x-auto -mx-4 px-4">
         <div className="flex gap-1.5 min-w-max">
-          <button
-            type="button"
+          <FilterChip
+            active={statusFilter === null}
             onClick={() => setStatusFilter(null)}
-            className={clsx(
-              "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors shrink-0",
-              statusFilter === null
-                ? "bg-primary text-white"
-                : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-            )}
-          >
-            {t.psychologist.codeAny}
-          </button>
+            label={t.psychologist.codeAny}
+          />
           {STATUSES.map(({ key, labelKey }) => (
-            <button
+            <FilterChip
               key={key}
-              type="button"
+              active={statusFilter === key}
               onClick={() =>
                 setStatusFilter((prev) => (prev === key ? null : key))
               }
-              className={clsx(
-                "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors shrink-0",
-                statusFilter === key
-                  ? "bg-primary text-white"
-                  : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-              )}
-            >
-              {(t.psychologist as unknown as Translations)[labelKey]}
-            </button>
+              label={(t.psychologist as unknown as Translations)[labelKey]}
+            />
           ))}
         </div>
       </div>
@@ -130,70 +197,64 @@ export function AssignmentsSegment() {
           <Loader2 size={24} className="animate-spin text-text-light" />
         </div>
       ) : !data || data.length === 0 ? (
-        <div className="flex flex-col items-center py-12">
-          <ClipboardList size={36} className="text-text-light mb-2" />
+        <div className="flex flex-col items-center py-12 rounded-xl bg-surface border border-border-light">
+          <ClipboardList size={28} className="text-text-light mb-2" />
           <p className="text-sm text-text-light">
             {t.psychologist.assignmentsEmpty}
           </p>
         </div>
       ) : (
-        <ul className="space-y-2">
-          {data.map((row) => {
-            const canCancel =
-              row.status === "pending" || row.status === "in_progress";
-            return (
+        <DataTable
+          data={data}
+          columns={columns}
+          getRowKey={(row) => row.id}
+          density="compact"
+        />
+      )}
+
+      {/* Inline message rows below the table for assignments with student-message */}
+      {data && data.length > 0 && (
+        <ul className="space-y-1.5">
+          {data
+            .filter((row) => row.studentMessage)
+            .map((row) => (
               <li
-                key={row.id}
-                className="flex items-start gap-3 p-3 rounded-xl bg-surface border border-border shadow-sm"
+                key={`msg-${row.id}`}
+                className="flex items-start gap-2 px-3 py-2 rounded-lg bg-surface-secondary text-[11px] text-text-light"
               >
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-semibold text-text-main truncate">
-                      {targetLabel(row)}
-                    </span>
-                    <span
-                      className={clsx(
-                        "shrink-0 inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold border",
-                        statusColor(row.status),
-                      )}
-                    >
-                      {(t.psychologist as unknown as Translations)[
-                        STATUSES.find((s) => s.key === row.status)?.labelKey ??
-                          "assignmentStatusPending"
-                      ]}
-                    </span>
-                  </div>
-                  <div className="mt-0.5 text-xs text-text-light truncate">
-                    {testNameForRow(row)}
-                  </div>
-                  {row.dueDate && (
-                    <div className="mt-1 inline-flex items-center gap-1 text-[11px] text-text-light">
-                      <Calendar size={10} />
-                      {t.psychologist.assignmentDueDate}:{" "}
-                      {new Date(row.dueDate).toLocaleDateString()}
-                    </div>
-                  )}
-                  {row.studentMessage && (
-                    <div className="mt-1.5 px-2 py-1 rounded-md bg-surface-secondary text-[11px] text-text-main">
-                      “{row.studentMessage}”
-                    </div>
-                  )}
-                </div>
-                {canCancel && (
-                  <button
-                    type="button"
-                    onClick={() => handleCancel(row.id)}
-                    disabled={cancelMutation.isPending}
-                    className="shrink-0 inline-flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-border text-xs font-semibold text-text-light hover:bg-surface-hover disabled:opacity-50"
-                  >
-                    {t.psychologist.cancelAssignment}
-                  </button>
-                )}
+                <span className="font-semibold text-text-main shrink-0">
+                  {targetLabel(row)}:
+                </span>
+                <span className="italic">"{row.studentMessage}"</span>
               </li>
-            );
-          })}
+            ))}
         </ul>
       )}
     </div>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors shrink-0 border",
+        active
+          ? "bg-brand-soft text-brand-deep border-brand/30"
+          : "bg-surface-secondary text-text-light border-border-light hover:bg-surface-hover",
+      )}
+    >
+      {label}
+    </button>
   );
 }

--- a/packages/psychologist-app/src/components/diagnostics/DiagnosticsFiltersSheet.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/DiagnosticsFiltersSheet.tsx
@@ -67,136 +67,78 @@ export function DiagnosticsFiltersSheet({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col justify-end">
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative bg-surface rounded-t-2xl px-5 pt-2 pb-6 max-h-[90dvh] overflow-y-auto animate-fade-in-up">
-        <div className="flex justify-center py-2">
-          <div className="w-10 h-1 rounded-full bg-border-light" />
-        </div>
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-base font-bold text-text-main">
+      <div className="relative w-full max-w-lg rounded-2xl bg-surface shadow-xl animate-fade-in-up flex flex-col max-h-[85dvh]">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-border-light">
+          <h3 className="text-lg font-bold text-text-main">
             {t.psychologist.filtersTitle}
           </h3>
           <button
             onClick={onClose}
             aria-label={t.common.cancel}
-            className="p-1.5 rounded-md hover:bg-surface-hover text-text-light"
+            className="w-8 h-8 rounded-lg flex items-center justify-center bg-surface-secondary hover:bg-surface-hover text-text-light"
           >
-            <X size={18} />
+            <X size={16} />
           </button>
         </div>
 
-        <div className="space-y-4">
-          <div>
-            <label className="block text-xs font-medium text-text-main mb-1">
-              {t.psychologist.filtersTest}
-            </label>
-            <div className="flex flex-wrap gap-1.5">
-              <button
-                type="button"
-                onClick={() => setTestSlug("")}
-                className={clsx(
-                  "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                  testSlug === ""
-                    ? "bg-primary text-white"
-                    : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                )}
-              >
-                {t.psychologist.codeAny}
-              </button>
-              {tests.map((td) => (
-                <button
-                  key={td.slug}
-                  type="button"
-                  onClick={() =>
-                    setTestSlug(testSlug === td.slug ? "" : td.slug)
-                  }
-                  className={clsx(
-                    "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                    testSlug === td.slug
-                      ? "bg-primary text-white"
-                      : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                  )}
-                >
-                  {language === "kz" ? td.nameKz : td.nameRu}
-                </button>
-              ))}
-            </div>
-          </div>
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          <FilterSection label={t.psychologist.filtersTest}>
+            <Chip
+              active={testSlug === ""}
+              onClick={() => setTestSlug("")}
+              label={t.psychologist.codeAny}
+            />
+            {tests.map((td) => (
+              <Chip
+                key={td.slug}
+                active={testSlug === td.slug}
+                onClick={() =>
+                  setTestSlug(testSlug === td.slug ? "" : td.slug)
+                }
+                label={language === "kz" ? td.nameKz : td.nameRu}
+              />
+            ))}
+          </FilterSection>
 
-          <div>
-            <label className="block text-xs font-medium text-text-main mb-1">
-              {t.psychologist.filtersSeverity}
-            </label>
-            <div className="flex flex-wrap gap-1.5">
-              <button
-                type="button"
-                onClick={() => setSeverity("")}
-                className={clsx(
-                  "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                  severity === ""
-                    ? "bg-primary text-white"
-                    : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                )}
-              >
-                {t.psychologist.codeAny}
-              </button>
-              {SEVERITIES.map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  onClick={() => setSeverity(severity === s ? "" : s)}
-                  className={clsx(
-                    "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                    severity === s
-                      ? "bg-primary text-white"
-                      : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                  )}
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          </div>
+          <FilterSection label={t.psychologist.filtersSeverity}>
+            <Chip
+              active={severity === ""}
+              onClick={() => setSeverity("")}
+              label={t.psychologist.codeAny}
+            />
+            {SEVERITIES.map((s) => (
+              <Chip
+                key={s}
+                active={severity === s}
+                onClick={() => setSeverity(severity === s ? "" : s)}
+                label={s}
+              />
+            ))}
+          </FilterSection>
 
-          <div>
-            <label className="block text-xs font-medium text-text-main mb-1">
-              {t.psychologist.filtersGrade}
-            </label>
-            <div className="flex flex-wrap gap-1.5">
-              <button
-                type="button"
-                onClick={() => setGrade("")}
-                className={clsx(
-                  "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                  grade === ""
-                    ? "bg-primary text-white"
-                    : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                )}
-              >
-                {t.psychologist.codeAny}
-              </button>
-              {GRADES.map((g) => (
-                <button
-                  key={g}
-                  type="button"
-                  onClick={() => setGrade(grade === String(g) ? "" : String(g))}
-                  className={clsx(
-                    "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                    grade === String(g)
-                      ? "bg-primary text-white"
-                      : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                  )}
-                >
-                  {g}
-                </button>
-              ))}
-            </div>
-          </div>
+          <FilterSection label={t.psychologist.filtersGrade}>
+            <Chip
+              active={grade === ""}
+              onClick={() => setGrade("")}
+              label={t.psychologist.codeAny}
+            />
+            {GRADES.map((g) => (
+              <Chip
+                key={g}
+                active={grade === String(g)}
+                onClick={() => setGrade(grade === String(g) ? "" : String(g))}
+                label={String(g)}
+              />
+            ))}
+          </FilterSection>
 
           <div className="grid grid-cols-2 gap-2">
             <div>
-              <label className="block text-xs font-medium text-text-main mb-1">
+              <label className="block text-[11px] font-semibold uppercase tracking-wide text-text-light mb-1.5">
                 {t.psychologist.filtersDateFrom}
               </label>
               <input
@@ -207,7 +149,7 @@ export function DiagnosticsFiltersSheet({
               />
             </div>
             <div>
-              <label className="block text-xs font-medium text-text-main mb-1">
+              <label className="block text-[11px] font-semibold uppercase tracking-wide text-text-light mb-1.5">
                 {t.psychologist.filtersDateTo}
               </label>
               <input
@@ -218,25 +160,68 @@ export function DiagnosticsFiltersSheet({
               />
             </div>
           </div>
+        </div>
 
-          <div className="flex gap-2 pt-2">
-            <button
-              type="button"
-              onClick={reset}
-              className="flex-1 h-11 rounded-xl border border-border text-sm font-semibold text-text-light hover:bg-surface-hover"
-            >
-              {t.psychologist.filtersReset}
-            </button>
-            <button
-              type="button"
-              onClick={apply}
-              className="flex-[2] h-11 rounded-xl bg-primary text-white text-sm font-semibold hover:bg-primary-dark"
-            >
-              {t.psychologist.filtersApply}
-            </button>
-          </div>
+        {/* Footer */}
+        <div className="flex gap-2 px-5 py-3 border-t border-border-light">
+          <button
+            type="button"
+            onClick={reset}
+            className="flex-1 h-11 rounded-xl border border-border-light text-sm font-semibold text-text-light hover:bg-surface-hover"
+          >
+            {t.psychologist.filtersReset}
+          </button>
+          <button
+            type="button"
+            onClick={apply}
+            className="btn-press flex-[2] h-11 rounded-xl bg-primary text-white text-sm font-semibold hover:bg-primary-dark"
+          >
+            {t.psychologist.filtersApply}
+          </button>
         </div>
       </div>
     </div>
+  );
+}
+
+function FilterSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label className="block text-[11px] font-semibold uppercase tracking-wide text-text-light mb-1.5">
+        {label}
+      </label>
+      <div className="flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function Chip({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors border",
+        active
+          ? "bg-brand-soft text-brand-deep border-brand/30"
+          : "bg-surface-secondary text-text-light border-border-light hover:bg-surface-hover",
+      )}
+    >
+      {label}
+    </button>
   );
 }

--- a/packages/psychologist-app/src/components/diagnostics/ResultsSegment.tsx
+++ b/packages/psychologist-app/src/components/diagnostics/ResultsSegment.tsx
@@ -13,6 +13,8 @@ import { getResults, type DiagnosticsFilters } from "../../api/diagnostics.js";
 import { SeverityBadge } from "../ui/SeverityBadge.js";
 import { AiReportCard } from "./AiReportCard.js";
 import { ErrorState } from "../ui/ErrorState.js";
+import { DataTable, type DataTableColumn } from "../ui/DataTable.js";
+import type { DiagnosticResultRow } from "../../api/diagnostics.js";
 
 interface Props {
   filters: DiagnosticsFilters;
@@ -46,81 +48,117 @@ export function ResultsSegment({ filters }: Props) {
 
   if (!results || results.data.length === 0) {
     return (
-      <div className="flex flex-col items-center py-12">
-        <ClipboardList size={36} className="text-text-light mb-2" />
+      <div className="flex flex-col items-center py-12 rounded-xl bg-surface border border-border-light">
+        <ClipboardList size={28} className="text-text-light mb-2" />
         <p className="text-sm text-text-light">{t.common.noData}</p>
       </div>
     );
   }
 
+  const columns: DataTableColumn<DiagnosticResultRow>[] = [
+    {
+      key: "student",
+      header: t.psychologist.assignSelectStudent,
+      width: "30%",
+      cell: (row) => (
+        <div className="flex items-center gap-2.5 min-w-0">
+          <div className="w-7 h-7 rounded-full bg-brand-soft text-brand-deep flex items-center justify-center text-[11px] font-semibold shrink-0">
+            {(row.studentName ?? "S").charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0">
+            <div className="font-semibold text-text-main truncate text-sm">
+              {row.studentName ?? "Student"}
+            </div>
+            {row.studentGrade && (
+              <div className="text-[11px] text-text-light tabular-nums">
+                {row.studentGrade}
+                {row.studentClass ?? ""}
+              </div>
+            )}
+          </div>
+        </div>
+      ),
+    },
+    {
+      key: "test",
+      header: t.psychologist.diagnostics,
+      cell: (row) => (
+        <span className="text-text-light text-sm truncate block">
+          {row.testName ?? row.testSlug ?? row.testId}
+        </span>
+      ),
+      hideOnSmall: true,
+    },
+    {
+      key: "completedAt",
+      header: "",
+      width: "100px",
+      hideOnSmall: true,
+      cell: (row) => (
+        <span className="text-xs text-text-light tabular-nums">
+          {row.completedAt
+            ? new Date(row.completedAt).toLocaleDateString()
+            : "—"}
+        </span>
+      ),
+    },
+    {
+      key: "score",
+      header: "",
+      width: "90px",
+      align: "right",
+      cell: (row) => (
+        <div className="flex flex-col items-end gap-0.5">
+          {row.totalScore != null && (
+            <span className="text-xs font-bold text-text-main tabular-nums">
+              {row.totalScore}/{row.maxScore ?? "?"}
+            </span>
+          )}
+          {row.severity && <SeverityBadge severity={row.severity} />}
+        </div>
+      ),
+    },
+    {
+      key: "ai",
+      header: "",
+      width: "110px",
+      align: "right",
+      cell: (row) => (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setReportSession({
+              sessionId: row.sessionId,
+              studentName: row.studentName,
+              testName: row.testName,
+            });
+          }}
+          className="inline-flex items-center gap-1 rounded-md border border-brand/20 bg-brand-soft px-2 py-1 text-[11px] font-bold text-brand-deep hover:bg-brand/15 transition-colors"
+        >
+          <Sparkles size={11} />
+          AI-анализ
+        </button>
+      ),
+    },
+    {
+      key: "chevron",
+      header: "",
+      width: "24px",
+      align: "right",
+      cell: () => <ChevronRight size={14} className="text-text-light/40" />,
+    },
+  ];
+
   return (
     <>
-      <div className="space-y-2">
-        {results.data.map((row) => (
-          <div
-            key={row.sessionId}
-            className="w-full flex items-center gap-3 p-3 rounded-xl bg-surface border border-border shadow-sm transition-all hover:shadow-md"
-          >
-            <button
-              type="button"
-              onClick={() => navigate(`/students/${row.studentId}`)}
-              className="btn-press flex flex-1 min-w-0 items-center gap-3 text-left"
-            >
-              <div className="w-9 h-9 rounded-full bg-primary/10 text-primary flex items-center justify-center text-xs font-semibold shrink-0">
-                {(row.studentName ?? "S").charAt(0).toUpperCase()}
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-semibold text-text-main truncate">
-                    {row.studentName ?? "Student"}
-                  </span>
-                  {row.studentGrade && (
-                    <span className="text-xs text-text-light shrink-0">
-                      {row.studentGrade}
-                      {row.studentClass ?? ""}
-                    </span>
-                  )}
-                </div>
-                <div className="flex items-center gap-2 mt-0.5">
-                  <span className="text-xs text-text-light truncate">
-                    {row.testName ?? row.testSlug ?? row.testId}
-                  </span>
-                  <span className="text-xs text-text-light">&middot;</span>
-                  <span className="text-xs text-text-light">
-                    {row.completedAt
-                      ? new Date(row.completedAt).toLocaleDateString()
-                      : "—"}
-                  </span>
-                </div>
-              </div>
-              <div className="flex flex-col items-end gap-1 shrink-0">
-                {row.totalScore != null && (
-                  <span className="text-xs font-bold text-text-main">
-                    {row.totalScore}/{row.maxScore ?? "?"}
-                  </span>
-                )}
-                {row.severity && <SeverityBadge severity={row.severity} />}
-              </div>
-              <ChevronRight size={14} className="text-text-light/40 shrink-0" />
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                setReportSession({
-                  sessionId: row.sessionId,
-                  studentName: row.studentName,
-                  testName: row.testName,
-                })
-              }
-              className="shrink-0 inline-flex items-center gap-1 rounded-lg border border-indigo-200 bg-indigo-50 px-2 py-1.5 text-[11px] font-bold text-indigo-700 hover:bg-indigo-100"
-              title="AI-анализ"
-            >
-              <Sparkles size={12} />
-              AI-анализ
-            </button>
-          </div>
-        ))}
-      </div>
+      <DataTable
+        data={results.data}
+        columns={columns}
+        getRowKey={(row) => row.sessionId}
+        density="compact"
+        onRowClick={(row) => navigate(`/students/${row.studentId}`)}
+      />
 
       {reportSession && (
         <div
@@ -131,9 +169,9 @@ export function ResultsSegment({ filters }: Props) {
             className="bg-surface w-full sm:max-w-2xl max-h-[90vh] overflow-y-auto rounded-t-2xl sm:rounded-2xl shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="sticky top-0 flex items-center justify-between gap-3 border-b border-border bg-surface px-5 py-3">
+            <div className="sticky top-0 flex items-center justify-between gap-3 border-b border-border-light bg-surface px-5 py-3">
               <div className="min-w-0">
-                <p className="text-xs font-bold uppercase tracking-wider text-indigo-700">
+                <p className="text-[11px] font-bold uppercase tracking-wider text-brand-deep">
                   AI-анализ
                 </p>
                 <p className="truncate text-sm font-semibold text-text-main">

--- a/packages/psychologist-app/src/components/student/AchievementsStack.tsx
+++ b/packages/psychologist-app/src/components/student/AchievementsStack.tsx
@@ -13,22 +13,23 @@ export function AchievementsStack({ achievements, loading }: AchievementsStackPr
   const { language } = useLanguage();
 
   return (
-    <div className="bg-surface rounded-xl border border-border shadow-sm p-4">
+    <div className="bg-surface rounded-xl border border-border-light p-4">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-semibold text-ink">{t.achievements.title}</h3>
         {achievements && (
-          <span className="text-xs font-bold text-warning">
-            {achievements.earnedCount}/{achievements.totalCount}
+          <span className="text-[11px] font-bold tabular-nums text-text-light">
+            {achievements.earnedCount}
+            <span className="text-text-light/60">/{achievements.totalCount}</span>
           </span>
         )}
       </div>
       {loading ? (
         <div className="flex justify-center py-3">
-          <Loader2 size={18} className="animate-spin text-ink-muted" />
+          <Loader2 size={18} className="animate-spin text-text-light" />
         </div>
       ) : !achievements || achievements.achievements.length === 0 ? (
-        <div className="flex items-center gap-2 py-3 text-sm text-ink-muted">
-          <Award size={16} />
+        <div className="flex items-center gap-2 py-3 text-xs text-text-light">
+          <Award size={14} />
           {t.common.noData}
         </div>
       ) : (
@@ -48,20 +49,22 @@ export function AchievementsStack({ achievements, loading }: AchievementsStackPr
               <li
                 key={item.achievement.slug}
                 className={clsx(
-                  "flex items-center gap-3 rounded-lg px-2.5 py-2 border transition-colors",
+                  "flex items-center gap-2.5 rounded-lg px-2.5 py-2 transition-colors",
                   item.earned
-                    ? "border-warning/30 bg-warning/10"
-                    : "border-border-light bg-surface-secondary/40 opacity-60",
+                    ? "bg-warning/8 border border-warning/20"
+                    : "bg-surface-secondary/40 border border-transparent opacity-60",
                 )}
               >
-                <span className="text-xl shrink-0">{item.achievement.emoji}</span>
-                <span className="flex-1 text-xs font-medium text-ink leading-tight truncate">
+                <span className="text-lg shrink-0">{item.achievement.emoji}</span>
+                <span className="flex-1 text-xs font-medium text-text-main leading-tight truncate">
                   {name}
                 </span>
                 {item.earned && earnedDate ? (
-                  <span className="text-[10px] text-warning shrink-0">{earnedDate}</span>
+                  <span className="text-[10px] tabular-nums text-text-light shrink-0">
+                    {earnedDate}
+                  </span>
                 ) : (
-                  <Lock size={11} className="text-ink-muted shrink-0" />
+                  <Lock size={11} className="text-text-light/60 shrink-0" />
                 )}
               </li>
             );

--- a/packages/psychologist-app/src/components/student/StudentDetailHero.tsx
+++ b/packages/psychologist-app/src/components/student/StudentDetailHero.tsx
@@ -30,11 +30,11 @@ export function StudentDetailHero({ student, status, reason }: StudentDetailHero
       : "";
 
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-border bg-gradient-to-br from-brand-soft via-surface to-surface p-5">
+    <div className="relative overflow-hidden rounded-2xl border border-border-light bg-surface p-5">
       <div className="flex items-center gap-4">
         <div
           className={clsx(
-            "w-16 h-16 rounded-full bg-brand text-brand-fg flex items-center justify-center text-2xl font-bold shrink-0 ring-4 ring-surface shadow-sm",
+            "w-16 h-16 rounded-full bg-brand-soft text-brand-deep flex items-center justify-center text-2xl font-bold shrink-0",
             status === "crisis" && "animate-pulse-border",
           )}
         >
@@ -42,12 +42,12 @@ export function StudentDetailHero({ student, status, reason }: StudentDetailHero
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <h1 className="text-2xl font-bold tracking-tight text-ink truncate">
+            <h1 className="text-xl font-bold tracking-tight text-text-main truncate">
               {student.name}
             </h1>
             <span
               className={clsx(
-                "inline-block w-2.5 h-2.5 rounded-full ring-2 ring-surface",
+                "inline-block w-2 h-2 rounded-full",
                 statusDotColor[status],
                 status === "crisis" && "animate-pulse-border",
               )}
@@ -55,7 +55,7 @@ export function StudentDetailHero({ student, status, reason }: StudentDetailHero
             />
             <StatusBadge status={status} size="sm" />
           </div>
-          <p className="text-sm text-ink-muted mt-1 truncate">
+          <p className="text-sm text-text-light mt-1 truncate">
             {classLabel}
             {classLabel && student.email ? " · " : ""}
             {student.email}

--- a/packages/psychologist-app/src/components/student/StudentTestsSection.tsx
+++ b/packages/psychologist-app/src/components/student/StudentTestsSection.tsx
@@ -54,10 +54,10 @@ export function StudentTestsSection({ testResults }: StudentTestsSectionProps) {
                 className="w-full text-left p-3.5 flex items-start justify-between gap-3 disabled:cursor-default"
               >
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-semibold text-ink truncate">
+                  <p className="text-sm font-semibold text-text-main truncate">
                     {result.testName ?? result.testSlug ?? result.testId}
                   </p>
-                  <p className="text-xs text-ink-muted mt-0.5">
+                  <p className="text-[11px] text-text-light mt-0.5 tabular-nums">
                     {result.completedAt
                       ? new Date(result.completedAt).toLocaleDateString()
                       : "—"}
@@ -65,7 +65,7 @@ export function StudentTestsSection({ testResults }: StudentTestsSectionProps) {
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                   {result.totalScore != null && (
-                    <span className="text-sm font-bold text-ink">
+                    <span className="text-sm font-bold text-text-main tabular-nums">
                       {result.totalScore}/{result.maxScore ?? "?"}
                     </span>
                   )}

--- a/packages/psychologist-app/src/components/student/StudentTimeline.tsx
+++ b/packages/psychologist-app/src/components/student/StudentTimeline.tsx
@@ -130,10 +130,10 @@ export function StudentTimeline({
               key={f.key}
               onClick={() => onFilterChange(f.key)}
               className={clsx(
-                "px-3 py-1.5 rounded-full border text-xs font-medium transition-colors btn-press",
+                "px-3 py-1.5 rounded-full border text-xs font-semibold transition-colors btn-press",
                 active
-                  ? "bg-brand text-brand-fg border-brand"
-                  : "bg-surface text-ink border-border-light hover:bg-surface-hover",
+                  ? "bg-brand-soft text-brand-deep border-brand/30"
+                  : "bg-surface text-text-light border-border-light hover:bg-surface-hover",
               )}
             >
               {f.label}

--- a/packages/psychologist-app/src/components/students/GenerateCodesSheet.tsx
+++ b/packages/psychologist-app/src/components/students/GenerateCodesSheet.tsx
@@ -76,32 +76,33 @@ export function GenerateCodesSheet({
 
   if (!open) return null;
 
+  const canSubmit =
+    !generateMutation.isPending &&
+    studentNames.length >= 1 &&
+    studentNames.length <= 100;
+
   return (
-    <div className="fixed inset-0 z-50 flex flex-col justify-end">
-      <div
-        className="absolute inset-0 bg-black/40"
-        onClick={onClose}
-      />
-      <div className="relative bg-surface rounded-t-2xl px-5 pt-2 pb-6 max-h-[90dvh] overflow-y-auto animate-fade-in-up">
-        <div className="flex justify-center py-2">
-          <div className="w-10 h-1 rounded-full bg-border-light" />
-        </div>
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-base font-bold text-text-main">
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+      <div className="relative w-full max-w-lg rounded-2xl bg-surface shadow-xl animate-fade-in-up flex flex-col max-h-[85dvh]">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-border-light">
+          <h3 className="text-lg font-bold text-text-main">
             {t.psychologist.generateCodes}
           </h3>
           <button
             onClick={onClose}
             aria-label={t.common.cancel}
-            className="p-1.5 rounded-md hover:bg-surface-hover text-text-light"
+            className="w-8 h-8 rounded-lg flex items-center justify-center bg-surface-secondary hover:bg-surface-hover text-text-light"
           >
-            <X size={18} />
+            <X size={16} />
           </button>
         </div>
 
-        <div className="space-y-3">
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
           <div>
-            <label className="block text-xs font-medium text-text-main mb-1">
+            <label className="block text-[11px] font-semibold uppercase tracking-wide text-text-light mb-1.5">
               {t.psychologist.studentNamesLabel}
             </label>
             <textarea
@@ -112,91 +113,60 @@ export function GenerateCodesSheet({
               className="w-full px-3 py-2 rounded-lg border border-input-border bg-surface text-sm text-text-main
                 focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary resize-y"
             />
-            <p className="text-[11px] text-text-light mt-1">
+            <p className="text-[11px] text-text-light mt-1 tabular-nums">
               {studentNames.length} / 100
             </p>
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-main mb-1">
+            <label className="block text-[11px] font-semibold uppercase tracking-wide text-text-light mb-1.5">
               {t.auth.selectGrade}
             </label>
             <div className="flex flex-wrap gap-1.5">
-              <button
-                type="button"
+              <Chip
+                active={grade === null}
                 onClick={() => setGrade(null)}
-                className={clsx(
-                  "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                  grade === null
-                    ? "bg-primary text-white"
-                    : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                )}
-              >
-                {t.psychologist.codeAny}
-              </button>
+                label={t.psychologist.codeAny}
+              />
               {GRADES.map((g) => (
-                <button
+                <Chip
                   key={g}
-                  type="button"
+                  active={grade === g}
                   onClick={() => setGrade(grade === g ? null : g)}
-                  className={clsx(
-                    "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                    grade === g
-                      ? "bg-primary text-white"
-                      : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                  )}
-                >
-                  {g} {language === "kz" ? "сынып" : "класс"}
-                </button>
+                  label={`${g} ${language === "kz" ? "сынып" : "класс"}`}
+                />
               ))}
             </div>
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-text-main mb-1">
+            <label className="block text-[11px] font-semibold uppercase tracking-wide text-text-light mb-1.5">
               {t.auth.selectClass}
             </label>
             <div className="flex flex-wrap gap-1.5">
-              <button
-                type="button"
+              <Chip
+                active={classLetter === null}
                 onClick={() => setClassLetter(null)}
-                className={clsx(
-                  "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                  classLetter === null
-                    ? "bg-primary text-white"
-                    : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                )}
-              >
-                {t.psychologist.codeAny}
-              </button>
+                label={t.psychologist.codeAny}
+              />
               {CLASS_LETTERS.map((l) => (
-                <button
+                <Chip
                   key={l}
-                  type="button"
-                  onClick={() =>
-                    setClassLetter(classLetter === l ? null : l)
-                  }
-                  className={clsx(
-                    "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors",
-                    classLetter === l
-                      ? "bg-primary text-white"
-                      : "bg-surface-secondary text-text-light hover:bg-surface-hover",
-                  )}
-                >
-                  {l}
-                </button>
+                  active={classLetter === l}
+                  onClick={() => setClassLetter(classLetter === l ? null : l)}
+                  label={l}
+                />
               ))}
             </div>
           </div>
+        </div>
 
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-border-light">
           <button
             onClick={() => generateMutation.mutate()}
-            disabled={
-              generateMutation.isPending ||
-              studentNames.length < 1 ||
-              studentNames.length > 100
-            }
-            className="w-full flex items-center justify-center gap-2 h-11 rounded-xl bg-primary text-white text-sm font-semibold hover:bg-primary-dark disabled:opacity-50 transition-colors"
+            disabled={!canSubmit}
+            className="btn-press w-full flex items-center justify-center gap-2 h-11 rounded-xl bg-primary text-white text-sm font-semibold hover:bg-primary-dark disabled:opacity-50 transition-colors"
           >
             {generateMutation.isPending && (
               <Loader2 size={14} className="animate-spin" />
@@ -206,5 +176,30 @@ export function GenerateCodesSheet({
         </div>
       </div>
     </div>
+  );
+}
+
+function Chip({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        "px-3 py-1.5 rounded-full text-xs font-semibold transition-colors border",
+        active
+          ? "bg-brand-soft text-brand-deep border-brand/30"
+          : "bg-surface-secondary text-text-light border-border-light hover:bg-surface-hover",
+      )}
+    >
+      {label}
+    </button>
   );
 }

--- a/packages/psychologist-app/src/components/students/PendingList.tsx
+++ b/packages/psychologist-app/src/components/students/PendingList.tsx
@@ -71,8 +71,8 @@ export function PendingList({ onGenerateNew }: PendingListProps) {
 
   if (visible.length === 0) {
     return (
-      <div className="flex flex-col items-center py-12">
-        <KeyRound size={36} className="text-text-light mb-2" />
+      <div className="flex flex-col items-center py-12 rounded-xl bg-surface border border-border-light">
+        <KeyRound size={28} className="text-text-light mb-2" />
         <p className="text-sm text-text-light">{t.psychologist.pendingEmpty}</p>
       </div>
     );
@@ -88,49 +88,52 @@ export function PendingList({ onGenerateNew }: PendingListProps) {
         }}
         onCancel={() => setRevokeId(null)}
       />
-      <div className="space-y-2">
+      <ul className="space-y-1.5">
         {visible.map((code) => {
           const status = getCodeStatus(code);
           const isExpired = status === "expired";
           return (
-            <div
+            <li
               key={code.id}
-              className="bg-surface rounded-xl border border-border shadow-sm p-4"
+              className="bg-surface rounded-xl border border-border-light p-3"
             >
-              <div className="flex items-start justify-between mb-2 gap-2">
-                <div className="flex flex-col gap-1 min-w-0 flex-1">
-                  <code className="text-sm font-mono font-medium text-text-main bg-surface-secondary px-2 py-1 rounded self-start">
+              <div className="flex items-start gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    {/* Name — primary 14/600 */}
+                    <span className="text-sm font-semibold text-text-main truncate">
+                      {code.studentRealName}
+                    </span>
+                    <span
+                      className={clsx(
+                        "inline-flex items-center px-1.5 py-0.5 text-[10px] font-bold rounded-full whitespace-nowrap border",
+                        isExpired
+                          ? "bg-surface-secondary text-text-light border-border-light"
+                          : "bg-success/10 text-success border-success/30",
+                      )}
+                    >
+                      {isExpired
+                        ? t.psychologist.codeExpired
+                        : t.psychologist.codeAvailable}
+                    </span>
+                  </div>
+                  {/* Code — mono, 13/500 */}
+                  <code className="inline-block mt-1.5 text-[13px] font-mono font-medium text-text-main bg-surface-secondary px-2 py-0.5 rounded">
                     {code.code}
                   </code>
-                  <div className="text-xs font-medium text-text-main truncate">
-                    {code.studentRealName}
+                  {/* Meta — 11/light */}
+                  <div className="text-[11px] text-text-light mt-1.5 tabular-nums">
+                    {code.grade ? `${code.grade}${code.classLetter ?? ""}` : "—"}
+                    {!isExpired && (
+                      <>
+                        {" · "}
+                        {t.psychologist.expiresInDays.replace(
+                          "{days}",
+                          String(daysUntil(code.expiresAt)),
+                        )}
+                      </>
+                    )}
                   </div>
-                </div>
-                <span
-                  className={clsx(
-                    "inline-flex items-center px-2 py-0.5 text-[10px] font-medium rounded-full whitespace-nowrap",
-                    isExpired
-                      ? "bg-text-light/15 text-text-light"
-                      : "bg-success/15 text-success",
-                  )}
-                >
-                  {isExpired
-                    ? t.psychologist.codeExpired
-                    : t.psychologist.codeAvailable}
-                </span>
-              </div>
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-xs text-text-light">
-                  {code.grade ? `${code.grade}${code.classLetter ?? ""}` : "—"}
-                  {!isExpired && (
-                    <>
-                      {" · "}
-                      {t.psychologist.expiresInDays.replace(
-                        "{days}",
-                        String(daysUntil(code.expiresAt)),
-                      )}
-                    </>
-                  )}
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
                   {isExpired ? (
@@ -142,9 +145,9 @@ export function PendingList({ onGenerateNew }: PendingListProps) {
                           classLetter: code.classLetter ?? null,
                         })
                       }
-                      className="btn-press flex items-center gap-1 px-2 py-1 rounded-md bg-primary/10 text-primary text-xs font-semibold hover:bg-primary/15 transition-colors"
+                      className="btn-press flex items-center gap-1 px-2 py-1 rounded-md bg-brand-soft text-brand-deep text-[11px] font-semibold hover:bg-brand/15 transition-colors"
                     >
-                      <RefreshCw size={12} />
+                      <RefreshCw size={11} />
                       {t.psychologist.generateNewCode}
                     </button>
                   ) : (
@@ -152,7 +155,7 @@ export function PendingList({ onGenerateNew }: PendingListProps) {
                       <button
                         onClick={() => copyCode(code.code, code.id)}
                         aria-label={t.common.copied}
-                        className="p-1.5 rounded-md hover:bg-surface-hover text-text-light hover:text-primary transition-colors"
+                        className="p-1.5 rounded-md hover:bg-surface-hover text-text-light hover:text-text-main transition-colors"
                       >
                         {copiedId === code.id ? (
                           <Check size={14} className="text-success" />
@@ -172,10 +175,10 @@ export function PendingList({ onGenerateNew }: PendingListProps) {
                   )}
                 </div>
               </div>
-            </div>
+            </li>
           );
         })}
-      </div>
+      </ul>
     </>
   );
 }

--- a/packages/psychologist-app/src/components/ui/ConfirmDialog.tsx
+++ b/packages/psychologist-app/src/components/ui/ConfirmDialog.tsx
@@ -1,3 +1,5 @@
+import { AlertCircle, HelpCircle } from "lucide-react";
+import { clsx } from "clsx";
 import { useT } from "../../hooks/useLanguage.js";
 
 interface ConfirmDialogProps {
@@ -23,33 +25,47 @@ export function ConfirmDialog({
 
   if (!open) return null;
 
+  const isDanger = variant === "danger";
+  const Icon = isDanger ? AlertCircle : HelpCircle;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center px-6">
       <div
-        className="absolute inset-0 bg-black/30 backdrop-blur-[2px]"
+        className="absolute inset-0 bg-black/40 backdrop-blur-[2px]"
         onClick={onCancel}
       />
       <div className="relative w-full max-w-sm rounded-2xl bg-surface p-6 shadow-xl animate-fade-in-up">
-        <h3 className="text-base font-bold text-text-main">
-          {title ?? t.common.confirmDelete}
-        </h3>
-        <p className="mt-2 text-sm text-text-light">
-          {description ?? t.common.confirmDeleteDescription}
-        </p>
-        <div className="mt-5 flex gap-3">
+        <div className="flex flex-col items-center text-center">
+          <div
+            className={clsx(
+              "w-14 h-14 rounded-full flex items-center justify-center mb-3",
+              isDanger ? "bg-danger/10 text-danger" : "bg-brand-soft text-brand-deep",
+            )}
+          >
+            <Icon size={26} strokeWidth={2} />
+          </div>
+          <h3 className="text-lg font-bold text-text-main">
+            {title ?? t.common.confirmDelete}
+          </h3>
+          <p className="mt-1.5 text-sm text-text-light leading-relaxed">
+            {description ?? t.common.confirmDeleteDescription}
+          </p>
+        </div>
+        <div className="mt-6 flex gap-2">
           <button
             onClick={onCancel}
-            className="btn-press flex-1 rounded-xl border border-border bg-surface py-2.5 text-sm font-bold text-text-main transition-all hover:bg-surface-hover"
+            className="btn-press flex-1 rounded-xl border border-border-light bg-surface py-2.5 text-sm font-semibold text-text-main transition-all hover:bg-surface-hover"
           >
             {t.common.cancel}
           </button>
           <button
             onClick={onConfirm}
-            className={`btn-press flex-1 rounded-xl py-2.5 text-sm font-bold text-white transition-all ${
-              variant === "danger"
+            className={clsx(
+              "btn-press flex-1 rounded-xl py-2.5 text-sm font-semibold text-white transition-all",
+              isDanger
                 ? "bg-danger hover:bg-danger/90"
-                : "bg-primary hover:bg-primary-dark"
-            }`}
+                : "bg-primary hover:bg-primary-dark",
+            )}
           >
             {confirmLabel ?? t.common.delete}
           </button>

--- a/packages/psychologist-mobapp/app/(auth)/onboarding.tsx
+++ b/packages/psychologist-mobapp/app/(auth)/onboarding.tsx
@@ -20,6 +20,8 @@ import {
   H1,
   H3,
   Input,
+  Stepper,
+  type StepperStep,
   Text,
 } from "../../components/ui";
 import { useT } from "../../lib/hooks/useLanguage";
@@ -222,7 +224,12 @@ export default function OnboardingScreen() {
 
   // ── School / Schedule shared chrome ──────────────────────────────
   const stepIndex = STEP_INDEX[step];
-  const progress = stepIndex / TOTAL_STEPS;
+
+  const stepperSteps: StepperStep[] = [
+    { id: "welcome", label: ob.wizardWelcomeTitle },
+    { id: "school", label: ob.wizardSchoolTitle },
+    { id: "schedule", label: ob.wizardScheduleTitle },
+  ];
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: c.bg }]}>
@@ -238,23 +245,11 @@ export default function OnboardingScreen() {
           >
             <Ionicons name="arrow-back" size={18} color={c.text} />
           </Pressable>
-          <Caption style={{ color: c.textLight }}>
-            {stepIndex + 1} {ob.stepOf} {TOTAL_STEPS}
-          </Caption>
           <View style={styles.backBtn} />
         </View>
 
-        <View style={styles.progressWrap}>
-          <View
-            style={[styles.progressTrack, { backgroundColor: c.surfaceSecondary }]}
-          >
-            <View
-              style={[
-                styles.progressFill,
-                { backgroundColor: c.primary, width: `${progress * 100}%` },
-              ]}
-            />
-          </View>
+        <View style={styles.stepperWrap}>
+          <Stepper steps={stepperSteps} current={stepIndex} />
         </View>
 
         <ScrollView
@@ -562,18 +557,9 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  progressWrap: {
-    paddingHorizontal: 20,
+  stepperWrap: {
+    paddingHorizontal: spacing.xl,
     marginBottom: spacing.lg,
-  },
-  progressTrack: {
-    height: 4,
-    borderRadius: 2,
-    overflow: "hidden",
-  },
-  progressFill: {
-    height: "100%",
-    borderRadius: 2,
   },
 
   // Step content

--- a/packages/psychologist-mobapp/app/(screens)/crisis/resolve/[signalId].tsx
+++ b/packages/psychologist-mobapp/app/(screens)/crisis/resolve/[signalId].tsx
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   KeyboardAvoidingView,
   Platform,
+  ActivityIndicator,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
@@ -17,7 +18,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 import { useT } from "../../../../lib/hooks/useLanguage";
-import { Text, Body, Button } from "../../../../components/ui";
+import { Text, Body } from "../../../../components/ui";
 import { useThemeColors, spacing, radius } from "../../../../lib/theme";
 import { crisisApi } from "../../../../lib/api/crisis";
 import { hapticLight, hapticSuccess } from "../../../../lib/haptics";
@@ -44,7 +45,6 @@ export default function ResolveSignalScreen() {
     documented: false,
   });
 
-  // Find signal in cached red+yellow feeds — no extra round-trip required.
   const { data: redData } = useQuery({
     queryKey: ["crisis", "feed", "red"],
     queryFn: () => crisisApi.getFeed("red"),
@@ -109,6 +109,7 @@ export default function ResolveSignalScreen() {
             contentContainerStyle={styles.scroll}
             keyboardShouldPersistTaps="handled"
           >
+            {/* Student hero — bigger with subtitle */}
             {signal && (
               <View
                 style={[
@@ -121,7 +122,7 @@ export default function ResolveSignalScreen() {
                 >
                   <Text
                     style={{
-                      fontSize: 16,
+                      fontSize: 18,
                       fontWeight: "700",
                       color: accent,
                     }}
@@ -130,15 +131,36 @@ export default function ResolveSignalScreen() {
                   </Text>
                 </View>
                 <View style={{ flex: 1, minWidth: 0 }}>
-                  <Body style={{ fontWeight: "600" }} numberOfLines={1}>
-                    {signal.studentName}
-                  </Body>
                   <Text
                     style={{
-                      fontSize: 14,
-                      lineHeight: 20,
+                      fontSize: 17,
+                      lineHeight: 22,
+                      fontFamily: "Inter_700Bold",
+                      color: c.text,
+                    }}
+                    numberOfLines={1}
+                  >
+                    {signal.studentName}
+                  </Text>
+                  <Text
+                    style={{
+                      fontSize: 11,
+                      lineHeight: 14,
                       color: c.textLight,
+                      textTransform: "uppercase",
+                      letterSpacing: 0.4,
+                      fontFamily: "Inter_500Medium",
                       marginTop: 2,
+                    }}
+                  >
+                    {t.psychologist.resolveSignalTitle}
+                  </Text>
+                  <Text
+                    style={{
+                      fontSize: 13,
+                      lineHeight: 18,
+                      color: c.textLight,
+                      marginTop: 6,
                     }}
                     numberOfLines={3}
                   >
@@ -148,87 +170,111 @@ export default function ResolveSignalScreen() {
               </View>
             )}
 
-            <View style={styles.checklist}>
-              {(
-                [
-                  {
-                    key: "contactedStudent" as const,
-                    icon: "call-outline" as const,
-                    label: t.psychologist.contactStudent,
-                  },
-                  {
-                    key: "contactedParent" as const,
-                    icon: "people-outline" as const,
-                    label: t.psychologist.contactParent,
-                  },
-                  {
-                    key: "documented" as const,
-                    icon: "document-text-outline" as const,
-                    label: t.psychologist.documentActions,
-                  },
-                ] as const
-              ).map(({ key, icon, label }) => {
-                const checked = state[key];
-                return (
-                  <Pressable
-                    key={key}
-                    onPress={() => {
-                      hapticLight();
-                      update({ [key]: !checked });
-                    }}
-                    style={[
-                      styles.checkItem,
-                      {
-                        backgroundColor: checked
-                          ? `${c.success}14`
-                          : c.surfaceSecondary,
-                        borderColor: checked
-                          ? `${c.success}33`
-                          : "transparent",
-                      },
-                    ]}
-                  >
-                    <View
+            {/* Actions section */}
+            <View>
+              <Text style={[styles.sectionEyebrow, { color: c.textLight }]}>
+                {t.psychologist.actionsTaken}
+              </Text>
+              <View style={styles.checklist}>
+                {(
+                  [
+                    {
+                      key: "contactedStudent" as const,
+                      icon: "call-outline" as const,
+                      label: t.psychologist.contactStudent,
+                    },
+                    {
+                      key: "contactedParent" as const,
+                      icon: "people-outline" as const,
+                      label: t.psychologist.contactParent,
+                    },
+                    {
+                      key: "documented" as const,
+                      icon: "document-text-outline" as const,
+                      label: t.psychologist.documentActions,
+                    },
+                  ] as const
+                ).map(({ key, icon, label }) => {
+                  const checked = state[key];
+                  return (
+                    <Pressable
+                      key={key}
+                      onPress={() => {
+                        hapticLight();
+                        update({ [key]: !checked });
+                      }}
                       style={[
-                        styles.checkbox,
+                        styles.checkItem,
                         {
-                          backgroundColor: checked ? c.success : "transparent",
-                          borderColor: checked ? c.success : c.border,
+                          backgroundColor: checked
+                            ? `${c.success}14`
+                            : c.surface,
+                          borderColor: checked
+                            ? `${c.success}33`
+                            : c.borderLight,
                         },
                       ]}
                     >
-                      {checked && (
-                        <Ionicons name="checkmark" size={14} color="#FFF" />
-                      )}
-                    </View>
-                    <Ionicons
-                      name={icon}
-                      size={18}
-                      color={checked ? c.success : c.textLight}
-                    />
-                    <Text style={{ color: c.text, flex: 1 }}>{label}</Text>
-                  </Pressable>
-                );
-              })}
+                      <View
+                        style={[
+                          styles.checkbox,
+                          {
+                            backgroundColor: checked
+                              ? c.success
+                              : "transparent",
+                            borderColor: checked ? c.success : c.border,
+                          },
+                        ]}
+                      >
+                        {checked && (
+                          <Ionicons name="checkmark" size={14} color="#FFF" />
+                        )}
+                      </View>
+                      <Ionicons
+                        name={icon}
+                        size={18}
+                        color={checked ? c.success : c.textLight}
+                      />
+                      <Text
+                        style={{
+                          color: c.text,
+                          flex: 1,
+                          fontSize: 14,
+                          fontFamily: "Inter_500Medium",
+                        }}
+                      >
+                        {label}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
             </View>
 
-            <TextInput
-              value={state.notes}
-              onChangeText={(text) => update({ notes: text })}
-              placeholder={t.psychologist.resolveNotesPlaceholder}
-              placeholderTextColor={c.textLight}
-              multiline
-              style={[
-                styles.notesInput,
-                {
-                  backgroundColor: c.surfaceSecondary,
-                  borderColor: c.border,
-                  color: c.text,
-                },
-              ]}
-            />
+            {/* Notes section */}
+            <View>
+              <Text style={[styles.sectionEyebrow, { color: c.textLight }]}>
+                {t.psychologist.resolveSignalNotes}
+              </Text>
+              <TextInput
+                value={state.notes}
+                onChangeText={(text) => update({ notes: text })}
+                placeholder={t.psychologist.resolveNotesPlaceholder}
+                placeholderTextColor={c.textLight}
+                multiline
+                style={[
+                  styles.notesInput,
+                  {
+                    backgroundColor: c.surface,
+                    borderColor: c.borderLight,
+                    color: c.text,
+                  },
+                ]}
+              />
+            </View>
           </ScrollView>
 
+          {/* Success CTA */}
           <View
             style={[
               styles.footer,
@@ -238,12 +284,30 @@ export default function ResolveSignalScreen() {
               },
             ]}
           >
-            <Button
-              title={t.psychologist.resolveSignal}
-              variant="primary"
-              onPress={() => resolveMutation.mutate()}
-              loading={resolveMutation.isPending}
-            />
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                resolveMutation.mutate();
+              }}
+              disabled={resolveMutation.isPending}
+              style={({ pressed }) => [
+                styles.successCta,
+                { backgroundColor: c.success },
+                pressed && !resolveMutation.isPending && { opacity: 0.92 },
+                resolveMutation.isPending && { opacity: 0.6 },
+              ]}
+            >
+              {resolveMutation.isPending ? (
+                <ActivityIndicator size="small" color="#FFF" />
+              ) : (
+                <>
+                  <Ionicons name="checkmark-circle" size={18} color="#FFF" />
+                  <Text style={styles.successCtaText}>
+                    {t.psychologist.resolveSignal}
+                  </Text>
+                </>
+              )}
+            </Pressable>
           </View>
         </KeyboardAvoidingView>
       </SafeAreaView>
@@ -257,7 +321,7 @@ const styles = StyleSheet.create({
   header: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
+    gap: spacing.md,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
     borderBottomWidth: 1,
@@ -273,30 +337,38 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingTop: spacing.md,
     paddingBottom: spacing.md,
-    gap: spacing.md,
+    gap: spacing.lg,
   },
   studentRow: {
     flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-    padding: 12,
+    alignItems: "flex-start",
+    gap: spacing.md,
+    padding: spacing.md,
     borderRadius: radius.lg,
     borderWidth: 1,
   },
   avatar: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: 48,
+    height: 48,
+    borderRadius: 24,
     alignItems: "center",
     justifyContent: "center",
+  },
+  sectionEyebrow: {
+    fontSize: 11,
+    lineHeight: 14,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    fontFamily: "Inter_600SemiBold",
+    marginBottom: spacing.sm,
   },
   checklist: { gap: 8 },
   checkItem: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
+    gap: spacing.md,
     padding: 14,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     borderWidth: 1,
   },
   checkbox: {
@@ -309,11 +381,11 @@ const styles = StyleSheet.create({
   },
   notesInput: {
     borderWidth: 1,
-    borderRadius: 16,
+    borderRadius: radius.lg,
     padding: 14,
     fontSize: 14,
     fontFamily: "Inter_400Regular",
-    minHeight: 100,
+    minHeight: 96,
     textAlignVertical: "top",
   },
   footer: {
@@ -321,5 +393,19 @@ const styles = StyleSheet.create({
     paddingTop: spacing.sm,
     paddingBottom: spacing.sm,
     borderTopWidth: 1,
+  },
+  successCta: {
+    height: 52,
+    borderRadius: radius.lg,
+    alignItems: "center",
+    justifyContent: "center",
+    flexDirection: "row",
+    gap: 8,
+  },
+  successCtaText: {
+    fontSize: 15,
+    fontFamily: "Inter_700Bold",
+    color: "#FFF",
+    letterSpacing: 0.2,
   },
 });

--- a/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-class.tsx
+++ b/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-class.tsx
@@ -13,8 +13,8 @@ import { useRouter, Stack, useLocalSearchParams } from "expo-router";
 import { useMutation } from "@tanstack/react-query";
 import { testDefinitions } from "@tirek/shared";
 import { useT, useLanguage } from "../../../lib/hooks/useLanguage";
-import { Text, Button } from "../../../components/ui";
-import { useThemeColors, radius } from "../../../lib/theme";
+import { Text, Button, Stepper, type StepperStep } from "../../../components/ui";
+import { useThemeColors, radius, spacing } from "../../../lib/theme";
 import { diagnosticsApi } from "../../../lib/api/diagnostics";
 import { hapticLight } from "../../../lib/haptics";
 
@@ -42,11 +42,18 @@ export default function AssignToClassScreen() {
       : null;
   const testName = td ? (language === "kz" ? td.nameKz : td.nameRu) : testSlug;
 
+  const [step, setStep] = useState(0);
   const [grade, setGrade] = useState<number | null>(null);
   const [classLetter, setClassLetter] = useState<string>("");
   const [dueDate, setDueDate] = useState(defaultDueDate());
   const [studentMessage, setStudentMessage] = useState("");
   const [success, setSuccess] = useState(false);
+
+  const steps: StepperStep[] = [
+    { id: "class", label: t.psychologist.assignSelectGrade },
+    { id: "details", label: t.psychologist.assignDueDateLabel },
+    { id: "preview", label: t.psychologist.assignSuccessTitle },
+  ];
 
   const mutation = useMutation({
     mutationFn: () =>
@@ -68,6 +75,7 @@ export default function AssignToClassScreen() {
   });
 
   const canSubmit = !!testSlug && grade !== null && !mutation.isPending;
+  const canGoNext = (step === 0 && grade !== null) || step === 1;
   const classLabel = grade !== null ? `${grade}${classLetter}` : "";
   const submitLabel =
     grade !== null
@@ -111,205 +119,377 @@ export default function AssignToClassScreen() {
           keyboardShouldPersistTaps="handled"
         >
           {td && (
-            <Text variant="bodyLight" style={{ marginBottom: 8 }}>
+            <Text variant="bodyLight" style={{ marginBottom: spacing.sm }}>
               {testName}
             </Text>
           )}
 
-          {/* Grade chips */}
-          <Text variant="body" style={styles.fieldLabel}>
-            {t.psychologist.assignSelectGrade}
-          </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.chipsContainer}
-          >
-            {GRADES.map((g) => {
-              const active = grade === g;
-              return (
-                <Pressable
-                  key={g}
-                  onPress={() => {
-                    hapticLight();
-                    setGrade(g);
-                  }}
-                  style={[
-                    styles.chip,
-                    active
-                      ? { backgroundColor: c.primary }
-                      : { backgroundColor: c.surfaceSecondary },
-                  ]}
-                >
-                  <Text
-                    variant="small"
-                    style={{
-                      fontWeight: "600",
-                      color: active ? "#FFF" : c.textLight,
-                    }}
-                  >
-                    {g}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
+          {/* Stepper */}
+          <View style={styles.stepperWrap}>
+            <Stepper steps={steps} current={step} />
+          </View>
 
-          {/* Class letter chips */}
-          <Text variant="body" style={[styles.fieldLabel, { marginTop: 12 }]}>
-            {t.psychologist.assignSelectClassLetter}
-          </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.chipsContainer}
+          {/* Step content */}
+          <View
+            style={[
+              styles.card,
+              { backgroundColor: c.surface, borderColor: c.borderLight },
+            ]}
           >
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                setClassLetter("");
-              }}
-              style={[
-                styles.chip,
-                classLetter === ""
-                  ? { backgroundColor: c.primary }
-                  : { backgroundColor: c.surfaceSecondary },
-              ]}
-            >
-              <Text
-                variant="small"
-                style={{
-                  fontWeight: "600",
-                  color: classLetter === "" ? "#FFF" : c.textLight,
-                }}
-              >
-                {t.psychologist.allClasses}
-              </Text>
-            </Pressable>
-            {CLASS_LETTERS.map((l) => {
-              const active = classLetter === l;
-              return (
-                <Pressable
-                  key={l}
-                  onPress={() => {
-                    hapticLight();
-                    setClassLetter(l);
-                  }}
-                  style={[
-                    styles.chip,
-                    active
-                      ? { backgroundColor: c.primary }
-                      : { backgroundColor: c.surfaceSecondary },
-                  ]}
-                >
-                  <Text
-                    variant="small"
-                    style={{
-                      fontWeight: "600",
-                      color: active ? "#FFF" : c.textLight,
-                    }}
-                  >
-                    {l}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </ScrollView>
-
-          {/* Due date */}
-          <Text variant="body" style={styles.fieldLabel}>
-            {t.psychologist.assignDueDateLabel}
-          </Text>
-          <View style={styles.dueDateRow}>
-            <View
-              style={[
-                styles.dateInput,
-                { borderColor: c.borderLight, backgroundColor: c.surface },
-              ]}
-            >
-              <Ionicons
-                name="calendar-outline"
-                size={16}
-                color={c.textLight}
-              />
-              <TextInput
-                value={dueDate}
-                onChangeText={setDueDate}
-                placeholder="YYYY-MM-DD"
-                placeholderTextColor={c.textLight}
-                style={[styles.dateText, { color: c.text }]}
-                maxLength={10}
-              />
-            </View>
-            {!!dueDate && (
-              <Pressable
-                onPress={() => {
-                  hapticLight();
-                  setDueDate("");
-                }}
-                style={[
-                  styles.clearBtn,
-                  { borderColor: c.borderLight, backgroundColor: c.surface },
-                ]}
-              >
-                <Ionicons name="close" size={14} color={c.textLight} />
-                <Text variant="caption" style={{ color: c.textLight }}>
-                  {t.psychologist.assignDueDateClear}
+            {step === 0 && (
+              <>
+                <Text style={[styles.fieldLabel, { color: c.text }]}>
+                  {t.psychologist.assignSelectGrade}
                 </Text>
-              </Pressable>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.chipsContainer}
+                >
+                  {GRADES.map((g) => {
+                    const active = grade === g;
+                    return (
+                      <Pressable
+                        key={g}
+                        onPress={() => {
+                          hapticLight();
+                          setGrade(g);
+                        }}
+                        style={[
+                          styles.chip,
+                          active
+                            ? { backgroundColor: c.primary }
+                            : {
+                                backgroundColor: c.surfaceSecondary,
+                                borderColor: c.borderLight,
+                                borderWidth: 1,
+                              },
+                        ]}
+                      >
+                        <Text
+                          style={{
+                            fontSize: 13,
+                            fontFamily: "Inter_600SemiBold",
+                            color: active ? "#FFF" : c.text,
+                          }}
+                        >
+                          {g}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+
+                <Text
+                  style={[
+                    styles.fieldLabel,
+                    { color: c.text, marginTop: spacing.lg },
+                  ]}
+                >
+                  {t.psychologist.assignSelectClassLetter}
+                </Text>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.chipsContainer}
+                >
+                  <Pressable
+                    onPress={() => {
+                      hapticLight();
+                      setClassLetter("");
+                    }}
+                    style={[
+                      styles.chip,
+                      classLetter === ""
+                        ? { backgroundColor: c.primary }
+                        : {
+                            backgroundColor: c.surfaceSecondary,
+                            borderColor: c.borderLight,
+                            borderWidth: 1,
+                          },
+                    ]}
+                  >
+                    <Text
+                      style={{
+                        fontSize: 13,
+                        fontFamily: "Inter_600SemiBold",
+                        color: classLetter === "" ? "#FFF" : c.text,
+                      }}
+                    >
+                      {t.psychologist.allClasses}
+                    </Text>
+                  </Pressable>
+                  {CLASS_LETTERS.map((l) => {
+                    const active = classLetter === l;
+                    return (
+                      <Pressable
+                        key={l}
+                        onPress={() => {
+                          hapticLight();
+                          setClassLetter(l);
+                        }}
+                        style={[
+                          styles.chip,
+                          active
+                            ? { backgroundColor: c.primary }
+                            : {
+                                backgroundColor: c.surfaceSecondary,
+                                borderColor: c.borderLight,
+                                borderWidth: 1,
+                              },
+                        ]}
+                      >
+                        <Text
+                          style={{
+                            fontSize: 13,
+                            fontFamily: "Inter_600SemiBold",
+                            color: active ? "#FFF" : c.text,
+                          }}
+                        >
+                          {l}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+              </>
+            )}
+
+            {step === 1 && (
+              <>
+                <Text style={[styles.fieldLabel, { color: c.text }]}>
+                  {t.psychologist.assignDueDateLabel}
+                </Text>
+                <View style={styles.dueDateRow}>
+                  <View
+                    style={[
+                      styles.dateInput,
+                      { borderColor: c.borderLight, backgroundColor: c.bg },
+                    ]}
+                  >
+                    <Ionicons
+                      name="calendar-outline"
+                      size={16}
+                      color={c.textLight}
+                    />
+                    <TextInput
+                      value={dueDate}
+                      onChangeText={setDueDate}
+                      placeholder="YYYY-MM-DD"
+                      placeholderTextColor={c.textLight}
+                      style={[styles.dateText, { color: c.text }]}
+                      maxLength={10}
+                    />
+                  </View>
+                  {!!dueDate && (
+                    <Pressable
+                      onPress={() => {
+                        hapticLight();
+                        setDueDate("");
+                      }}
+                      style={[
+                        styles.clearBtn,
+                        { borderColor: c.borderLight, backgroundColor: c.bg },
+                      ]}
+                    >
+                      <Ionicons name="close" size={14} color={c.textLight} />
+                      <Text variant="caption" style={{ color: c.textLight }}>
+                        {t.psychologist.assignDueDateClear}
+                      </Text>
+                    </Pressable>
+                  )}
+                </View>
+
+                <Text
+                  style={[
+                    styles.fieldLabel,
+                    { color: c.text, marginTop: spacing.lg },
+                  ]}
+                >
+                  {t.psychologist.assignMessageOptionalLabel}
+                </Text>
+                <TextInput
+                  value={studentMessage}
+                  onChangeText={(v) =>
+                    setStudentMessage(v.slice(0, STUDENT_MESSAGE_MAX))
+                  }
+                  placeholder={t.psychologist.assignMessageClassPlaceholder}
+                  placeholderTextColor={c.textLight}
+                  multiline
+                  numberOfLines={3}
+                  maxLength={STUDENT_MESSAGE_MAX}
+                  style={[
+                    styles.messageInput,
+                    {
+                      borderColor: c.borderLight,
+                      color: c.text,
+                      backgroundColor: c.bg,
+                    },
+                  ]}
+                />
+                <Text
+                  variant="caption"
+                  style={{ marginTop: 4, color: c.textLight }}
+                >
+                  {studentMessage.length} / {STUDENT_MESSAGE_MAX} —{" "}
+                  {t.psychologist.studentMessageMaxHint}
+                </Text>
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                <Text style={[styles.previewTitle, { color: c.text }]}>
+                  {t.psychologist.assignSuccessTitle}
+                </Text>
+                <PreviewRow
+                  icon="clipboard-outline"
+                  label={t.psychologist.diagnostics}
+                  value={testName}
+                  c={c}
+                />
+                <PreviewRow
+                  icon="people-outline"
+                  label={t.psychologist.assignSelectGrade}
+                  value={
+                    classLabel ||
+                    (classLetter
+                      ? `— · ${classLetter}`
+                      : t.psychologist.allClasses)
+                  }
+                  c={c}
+                />
+                <PreviewRow
+                  icon="calendar-outline"
+                  label={t.psychologist.assignDueDateLabel}
+                  value={dueDate || "—"}
+                  c={c}
+                />
+                {studentMessage.trim() && (
+                  <PreviewRow
+                    icon="chatbubble-outline"
+                    label={t.psychologist.assignMessageOptionalLabel}
+                    value={studentMessage.trim()}
+                    c={c}
+                    last
+                  />
+                )}
+                {mutation.isError && (
+                  <View
+                    style={[
+                      styles.errorBanner,
+                      { backgroundColor: `${c.danger}1A` },
+                    ]}
+                  >
+                    <Text variant="body" style={{ color: c.danger }}>
+                      {t.common.error}
+                    </Text>
+                  </View>
+                )}
+              </>
             )}
           </View>
 
-          {/* Class message */}
-          <Text variant="body" style={styles.fieldLabel}>
-            {t.psychologist.assignMessageOptionalLabel}
-          </Text>
-          <TextInput
-            value={studentMessage}
-            onChangeText={(v) =>
-              setStudentMessage(v.slice(0, STUDENT_MESSAGE_MAX))
-            }
-            placeholder={t.psychologist.assignMessageClassPlaceholder}
-            placeholderTextColor={c.textLight}
-            multiline
-            numberOfLines={3}
-            maxLength={STUDENT_MESSAGE_MAX}
-            style={[
-              styles.messageInput,
-              {
-                borderColor: c.borderLight,
-                color: c.text,
-                backgroundColor: c.surface,
-              },
-            ]}
-          />
-          <Text variant="caption" style={{ marginTop: 4 }}>
-            {studentMessage.length} / {STUDENT_MESSAGE_MAX} —{" "}
-            {t.psychologist.studentMessageMaxHint}
-          </Text>
-
-          {mutation.isError && (
-            <View
-              style={[styles.errorBanner, { backgroundColor: `${c.danger}1A` }]}
+          {/* Step navigation */}
+          <View style={styles.navRow}>
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                setStep((s) => Math.max(0, s - 1));
+              }}
+              disabled={step === 0}
+              style={[
+                styles.navBack,
+                { borderColor: c.borderLight, backgroundColor: c.surface },
+                step === 0 && { opacity: 0.4 },
+              ]}
             >
-              <Text variant="body" style={{ color: c.danger }}>
-                {t.common.error}
+              <Text
+                style={{
+                  fontFamily: "Inter_600SemiBold",
+                  fontSize: 14,
+                  color: c.textLight,
+                }}
+              >
+                {t.common.back}
               </Text>
-            </View>
-          )}
-
-          <Button
-            title={submitLabel}
-            variant="primary"
-            size="lg"
-            onPress={() => mutation.mutate()}
-            disabled={!canSubmit}
-            loading={mutation.isPending}
-            style={{ marginTop: 16 }}
-          />
+            </Pressable>
+            {step < steps.length - 1 ? (
+              <Button
+                title={t.common.next}
+                variant="primary"
+                size="md"
+                onPress={() => setStep((s) => Math.min(steps.length - 1, s + 1))}
+                disabled={!canGoNext}
+                fullWidth={false}
+                style={{ flex: 1 }}
+              />
+            ) : (
+              <Button
+                title={submitLabel}
+                variant="primary"
+                size="md"
+                onPress={() => mutation.mutate()}
+                disabled={!canSubmit}
+                loading={mutation.isPending}
+                fullWidth={false}
+                style={{ flex: 1 }}
+              />
+            )}
+          </View>
         </ScrollView>
       </KeyboardAvoidingView>
     </>
+  );
+}
+
+function PreviewRow({
+  icon,
+  label,
+  value,
+  c,
+  last = false,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  value: string;
+  c: ReturnType<typeof useThemeColors>;
+  last?: boolean;
+}) {
+  return (
+    <View
+      style={[
+        styles.previewRow,
+        !last && { borderBottomColor: c.borderLight, borderBottomWidth: 1 },
+      ]}
+    >
+      <Ionicons name={icon} size={14} color={c.textLight} style={{ marginTop: 2 }} />
+      <View style={{ flex: 1 }}>
+        <Text
+          style={{
+            fontSize: 11,
+            lineHeight: 14,
+            color: c.textLight,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+            fontFamily: "Inter_500Medium",
+          }}
+        >
+          {label}
+        </Text>
+        <Text
+          style={{
+            fontSize: 14,
+            lineHeight: 20,
+            color: c.text,
+            fontFamily: "Inter_500Medium",
+            marginTop: 2,
+          }}
+        >
+          {value}
+        </Text>
+      </View>
+    </View>
   );
 }
 
@@ -318,23 +498,33 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scroll: {
-    padding: 20,
-    paddingBottom: 40,
-    gap: 8,
+    padding: spacing.xl,
+    paddingBottom: spacing["3xl"],
+    gap: spacing.md,
+  },
+  stepperWrap: {
+    paddingHorizontal: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  card: {
+    padding: spacing.lg,
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    gap: spacing.md,
   },
   fieldLabel: {
-    fontWeight: "600",
-    marginBottom: 4,
-    marginTop: 8,
+    fontFamily: "Inter_600SemiBold",
+    fontSize: 13,
   },
   chipsContainer: {
-    gap: 6,
+    gap: spacing.sm,
     flexDirection: "row",
     alignItems: "center",
+    paddingVertical: 2,
   },
   chip: {
     minWidth: 36,
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
     paddingVertical: 8,
     borderRadius: 999,
     alignItems: "center",
@@ -343,14 +533,14 @@ const styles = StyleSheet.create({
   dueDateRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: spacing.sm,
   },
   dateInput: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: spacing.sm,
     height: 44,
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
     borderRadius: radius.md,
     borderWidth: 1,
     flex: 1,
@@ -374,22 +564,45 @@ const styles = StyleSheet.create({
     minHeight: 80,
     borderWidth: 1,
     borderRadius: radius.md,
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
     paddingVertical: 10,
     fontSize: 14,
     fontFamily: "Inter_400Regular",
     textAlignVertical: "top",
   },
+  previewTitle: {
+    fontFamily: "Inter_700Bold",
+    fontSize: 14,
+  },
+  previewRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    paddingVertical: 10,
+  },
   errorBanner: {
-    padding: 12,
+    padding: spacing.md,
     borderRadius: radius.sm,
-    marginTop: 8,
+    marginTop: spacing.sm,
+  },
+  navRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  navBack: {
+    height: 44,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
   },
   successContainer: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    padding: 20,
+    padding: spacing.xl,
   },
   successIcon: {
     width: 64,
@@ -397,6 +610,6 @@ const styles = StyleSheet.create({
     borderRadius: 32,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: 16,
+    marginBottom: spacing.lg,
   },
 });

--- a/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-student.tsx
+++ b/packages/psychologist-mobapp/app/(screens)/diagnostics/assign-student.tsx
@@ -13,8 +13,8 @@ import { useRouter, Stack, useLocalSearchParams } from "expo-router";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { testDefinitions } from "@tirek/shared";
 import { useT, useLanguage } from "../../../lib/hooks/useLanguage";
-import { Text, Input, Button } from "../../../components/ui";
-import { useThemeColors, radius } from "../../../lib/theme";
+import { Text, Input, Button, Stepper, type StepperStep } from "../../../components/ui";
+import { useThemeColors, radius, spacing } from "../../../lib/theme";
 import { diagnosticsApi } from "../../../lib/api/diagnostics";
 import { studentsApi } from "../../../lib/api/students";
 import { hapticLight } from "../../../lib/haptics";
@@ -41,11 +41,18 @@ export default function AssignToStudentScreen() {
       : null;
   const testName = td ? (language === "kz" ? td.nameKz : td.nameRu) : testSlug;
 
+  const [step, setStep] = useState(0);
   const [studentId, setStudentId] = useState("");
   const [studentSearch, setStudentSearch] = useState("");
   const [dueDate, setDueDate] = useState(defaultDueDate());
   const [studentMessage, setStudentMessage] = useState("");
   const [success, setSuccess] = useState(false);
+
+  const steps: StepperStep[] = [
+    { id: "student", label: t.psychologist.assignSelectStudent },
+    { id: "details", label: t.psychologist.assignDueDateLabel },
+    { id: "preview", label: t.psychologist.assignSuccessTitle },
+  ];
 
   const { data: students } = useQuery({
     queryKey: ["students"],
@@ -80,6 +87,7 @@ export default function AssignToStudentScreen() {
   });
 
   const canSubmit = !!testSlug && !!studentId && !mutation.isPending;
+  const canGoNext = (step === 0 && !!studentId) || step === 1;
 
   const submitLabel = selectedStudent
     ? t.psychologist.assignSubmitForStudent.replace(
@@ -125,194 +133,358 @@ export default function AssignToStudentScreen() {
           keyboardShouldPersistTaps="handled"
         >
           {td && (
-            <Text variant="bodyLight" style={{ marginBottom: 8 }}>
+            <Text variant="bodyLight" style={{ marginBottom: spacing.sm }}>
               {testName}
             </Text>
           )}
 
-          {/* Student search */}
-          <Text variant="body" style={styles.fieldLabel}>
-            {t.psychologist.assignSelectStudent}
-          </Text>
-          <Input
-            icon="search-outline"
-            value={studentSearch}
-            onChangeText={setStudentSearch}
-            placeholder={`${t.common.search}...`}
-          />
+          {/* Stepper */}
+          <View style={styles.stepperWrap}>
+            <Stepper steps={steps} current={step} />
+          </View>
+
+          {/* Step content */}
           <View
             style={[
-              styles.studentList,
-              { borderColor: c.borderLight, backgroundColor: c.surface },
+              styles.card,
+              { backgroundColor: c.surface, borderColor: c.borderLight },
             ]}
           >
-            {filteredStudents.length > 0 ? (
-              <ScrollView
-                style={styles.studentScroll}
-                nestedScrollEnabled
-                keyboardShouldPersistTaps="handled"
-              >
-                {filteredStudents.map((s) => {
-                  const isSelected = studentId === s.id;
-                  return (
+            {step === 0 && (
+              <>
+                <Text style={[styles.fieldLabel, { color: c.text }]}>
+                  {t.psychologist.assignSelectStudent}
+                </Text>
+                <Input
+                  icon="search-outline"
+                  value={studentSearch}
+                  onChangeText={setStudentSearch}
+                  placeholder={`${t.common.search}...`}
+                />
+                <View
+                  style={[
+                    styles.studentList,
+                    { borderColor: c.borderLight, backgroundColor: c.bg },
+                  ]}
+                >
+                  {filteredStudents.length > 0 ? (
+                    <ScrollView
+                      style={styles.studentScroll}
+                      nestedScrollEnabled
+                      keyboardShouldPersistTaps="handled"
+                    >
+                      {filteredStudents.map((s) => {
+                        const isSelected = studentId === s.id;
+                        return (
+                          <Pressable
+                            key={s.id}
+                            onPress={() => {
+                              hapticLight();
+                              setStudentId(s.id);
+                            }}
+                            style={[
+                              styles.studentRow,
+                              {
+                                backgroundColor: isSelected
+                                  ? `${c.primary}0D`
+                                  : "transparent",
+                                borderBottomColor: c.borderLight,
+                              },
+                            ]}
+                          >
+                            <View
+                              style={[
+                                styles.miniAvatar,
+                                { backgroundColor: `${c.primary}1A` },
+                              ]}
+                            >
+                              <Text
+                                style={{
+                                  fontSize: 10,
+                                  fontWeight: "600",
+                                  color: c.primary,
+                                }}
+                              >
+                                {s.name.charAt(0).toUpperCase()}
+                              </Text>
+                            </View>
+                            <Text
+                              variant="body"
+                              style={{ flex: 1 }}
+                              numberOfLines={1}
+                            >
+                              {s.name}
+                            </Text>
+                            <Text variant="caption">
+                              {s.grade ?? ""}
+                              {s.classLetter ?? ""}
+                            </Text>
+                            {isSelected && (
+                              <Ionicons
+                                name="checkmark"
+                                size={16}
+                                color={c.primary}
+                              />
+                            )}
+                          </Pressable>
+                        );
+                      })}
+                    </ScrollView>
+                  ) : (
+                    <Text
+                      variant="bodyLight"
+                      style={{ textAlign: "center", padding: spacing.lg }}
+                    >
+                      {t.psychologist.assignSelectStudentEmpty}
+                    </Text>
+                  )}
+                </View>
+              </>
+            )}
+
+            {step === 1 && (
+              <>
+                <Text style={[styles.fieldLabel, { color: c.text }]}>
+                  {t.psychologist.assignDueDateLabel}
+                </Text>
+                <View style={styles.dueDateRow}>
+                  <View
+                    style={[
+                      styles.dateInput,
+                      { borderColor: c.borderLight, backgroundColor: c.bg },
+                    ]}
+                  >
+                    <Ionicons
+                      name="calendar-outline"
+                      size={16}
+                      color={c.textLight}
+                    />
+                    <TextInput
+                      value={dueDate}
+                      onChangeText={setDueDate}
+                      placeholder="YYYY-MM-DD"
+                      placeholderTextColor={c.textLight}
+                      style={[styles.dateText, { color: c.text }]}
+                      maxLength={10}
+                    />
+                  </View>
+                  {!!dueDate && (
                     <Pressable
-                      key={s.id}
                       onPress={() => {
                         hapticLight();
-                        setStudentId(s.id);
+                        setDueDate("");
                       }}
                       style={[
-                        styles.studentRow,
-                        {
-                          backgroundColor: isSelected
-                            ? `${c.primary}0D`
-                            : "transparent",
-                          borderBottomColor: c.borderLight,
-                        },
+                        styles.clearBtn,
+                        { borderColor: c.borderLight, backgroundColor: c.bg },
                       ]}
                     >
-                      <View
-                        style={[
-                          styles.miniAvatar,
-                          { backgroundColor: `${c.primary}1A` },
-                        ]}
-                      >
-                        <Text
-                          style={{
-                            fontSize: 10,
-                            fontWeight: "600",
-                            color: c.primary,
-                          }}
-                        >
-                          {s.name.charAt(0).toUpperCase()}
-                        </Text>
-                      </View>
-                      <Text
-                        variant="body"
-                        style={{ flex: 1 }}
-                        numberOfLines={1}
-                      >
-                        {s.name}
+                      <Ionicons name="close" size={14} color={c.textLight} />
+                      <Text variant="caption" style={{ color: c.textLight }}>
+                        {t.psychologist.assignDueDateClear}
                       </Text>
-                      <Text variant="caption">
-                        {s.grade ?? ""}
-                        {s.classLetter ?? ""}
-                      </Text>
-                      {isSelected && (
-                        <Ionicons
-                          name="checkmark"
-                          size={16}
-                          color={c.primary}
-                        />
-                      )}
                     </Pressable>
-                  );
-                })}
-              </ScrollView>
-            ) : (
-              <Text
-                variant="bodyLight"
-                style={{ textAlign: "center", padding: 16 }}
-              >
-                {t.psychologist.assignSelectStudentEmpty}
-              </Text>
+                  )}
+                </View>
+
+                <Text
+                  style={[
+                    styles.fieldLabel,
+                    { color: c.text, marginTop: spacing.lg },
+                  ]}
+                >
+                  {t.psychologist.studentMessageLabel}
+                </Text>
+                <TextInput
+                  value={studentMessage}
+                  onChangeText={(v) =>
+                    setStudentMessage(v.slice(0, STUDENT_MESSAGE_MAX))
+                  }
+                  placeholder={t.psychologist.studentMessagePlaceholder}
+                  placeholderTextColor={c.textLight}
+                  multiline
+                  numberOfLines={3}
+                  maxLength={STUDENT_MESSAGE_MAX}
+                  style={[
+                    styles.messageInput,
+                    {
+                      borderColor: c.borderLight,
+                      color: c.text,
+                      backgroundColor: c.bg,
+                    },
+                  ]}
+                />
+                <Text
+                  variant="caption"
+                  style={{ marginTop: 4, color: c.textLight }}
+                >
+                  {studentMessage.length} / {STUDENT_MESSAGE_MAX} —{" "}
+                  {t.psychologist.studentMessageMaxHint}
+                </Text>
+              </>
+            )}
+
+            {step === 2 && (
+              <>
+                <Text
+                  style={[
+                    styles.previewTitle,
+                    { color: c.text },
+                  ]}
+                >
+                  {t.psychologist.assignSuccessTitle}
+                </Text>
+                <PreviewRow
+                  icon="clipboard-outline"
+                  label={t.psychologist.diagnostics}
+                  value={testName}
+                  c={c}
+                />
+                <PreviewRow
+                  icon="person-outline"
+                  label={t.psychologist.assignSelectStudent}
+                  value={
+                    selectedStudent
+                      ? `${selectedStudent.name}${
+                          selectedStudent.grade
+                            ? ` · ${selectedStudent.grade}${selectedStudent.classLetter ?? ""}`
+                            : ""
+                        }`
+                      : "—"
+                  }
+                  c={c}
+                />
+                <PreviewRow
+                  icon="calendar-outline"
+                  label={t.psychologist.assignDueDateLabel}
+                  value={dueDate || "—"}
+                  c={c}
+                />
+                {studentMessage.trim() && (
+                  <PreviewRow
+                    icon="chatbubble-outline"
+                    label={t.psychologist.studentMessageLabel}
+                    value={studentMessage.trim()}
+                    c={c}
+                    last
+                  />
+                )}
+                {mutation.isError && (
+                  <View
+                    style={[
+                      styles.errorBanner,
+                      { backgroundColor: `${c.danger}1A` },
+                    ]}
+                  >
+                    <Text variant="body" style={{ color: c.danger }}>
+                      {t.common.error}
+                    </Text>
+                  </View>
+                )}
+              </>
             )}
           </View>
 
-          {/* Due date */}
-          <Text variant="body" style={styles.fieldLabel}>
-            {t.psychologist.assignDueDateLabel}
-          </Text>
-          <View style={styles.dueDateRow}>
-            <View
+          {/* Step navigation */}
+          <View style={styles.navRow}>
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                setStep((s) => Math.max(0, s - 1));
+              }}
+              disabled={step === 0}
               style={[
-                styles.dateInput,
+                styles.navBack,
                 { borderColor: c.borderLight, backgroundColor: c.surface },
+                step === 0 && { opacity: 0.4 },
               ]}
             >
-              <Ionicons
-                name="calendar-outline"
-                size={16}
-                color={c.textLight}
-              />
-              <TextInput
-                value={dueDate}
-                onChangeText={setDueDate}
-                placeholder="YYYY-MM-DD"
-                placeholderTextColor={c.textLight}
-                style={[styles.dateText, { color: c.text }]}
-                maxLength={10}
-              />
-            </View>
-            {!!dueDate && (
-              <Pressable
-                onPress={() => {
-                  hapticLight();
-                  setDueDate("");
+              <Text
+                style={{
+                  fontFamily: "Inter_600SemiBold",
+                  fontSize: 14,
+                  color: c.textLight,
                 }}
-                style={[
-                  styles.clearBtn,
-                  { borderColor: c.borderLight, backgroundColor: c.surface },
-                ]}
               >
-                <Ionicons name="close" size={14} color={c.textLight} />
-                <Text variant="caption" style={{ color: c.textLight }}>
-                  {t.psychologist.assignDueDateClear}
-                </Text>
-              </Pressable>
+                {t.common.back}
+              </Text>
+            </Pressable>
+            {step < steps.length - 1 ? (
+              <Button
+                title={t.common.next}
+                variant="primary"
+                size="md"
+                onPress={() => setStep((s) => Math.min(steps.length - 1, s + 1))}
+                disabled={!canGoNext}
+                fullWidth={false}
+                style={{ flex: 1 }}
+              />
+            ) : (
+              <Button
+                title={submitLabel}
+                variant="primary"
+                size="md"
+                onPress={() => mutation.mutate()}
+                disabled={!canSubmit}
+                loading={mutation.isPending}
+                fullWidth={false}
+                style={{ flex: 1 }}
+              />
             )}
           </View>
-
-          {/* Student message */}
-          <Text variant="body" style={styles.fieldLabel}>
-            {t.psychologist.studentMessageLabel}
-          </Text>
-          <TextInput
-            value={studentMessage}
-            onChangeText={(v) =>
-              setStudentMessage(v.slice(0, STUDENT_MESSAGE_MAX))
-            }
-            placeholder={t.psychologist.studentMessagePlaceholder}
-            placeholderTextColor={c.textLight}
-            multiline
-            numberOfLines={3}
-            maxLength={STUDENT_MESSAGE_MAX}
-            style={[
-              styles.messageInput,
-              {
-                borderColor: c.borderLight,
-                color: c.text,
-                backgroundColor: c.surface,
-              },
-            ]}
-          />
-          <Text variant="caption" style={{ marginTop: 4 }}>
-            {studentMessage.length} / {STUDENT_MESSAGE_MAX} —{" "}
-            {t.psychologist.studentMessageMaxHint}
-          </Text>
-
-          {mutation.isError && (
-            <View
-              style={[styles.errorBanner, { backgroundColor: `${c.danger}1A` }]}
-            >
-              <Text variant="body" style={{ color: c.danger }}>
-                {t.common.error}
-              </Text>
-            </View>
-          )}
-
-          <Button
-            title={submitLabel}
-            variant="primary"
-            size="lg"
-            onPress={() => mutation.mutate()}
-            disabled={!canSubmit}
-            loading={mutation.isPending}
-            style={{ marginTop: 16 }}
-          />
         </ScrollView>
       </KeyboardAvoidingView>
     </>
+  );
+}
+
+function PreviewRow({
+  icon,
+  label,
+  value,
+  c,
+  last = false,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  label: string;
+  value: string;
+  c: ReturnType<typeof useThemeColors>;
+  last?: boolean;
+}) {
+  return (
+    <View
+      style={[
+        styles.previewRow,
+        !last && { borderBottomColor: c.borderLight, borderBottomWidth: 1 },
+      ]}
+    >
+      <Ionicons name={icon} size={14} color={c.textLight} style={{ marginTop: 2 }} />
+      <View style={{ flex: 1 }}>
+        <Text
+          style={{
+            fontSize: 11,
+            lineHeight: 14,
+            color: c.textLight,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+            fontFamily: "Inter_500Medium",
+          }}
+        >
+          {label}
+        </Text>
+        <Text
+          style={{
+            fontSize: 14,
+            lineHeight: 20,
+            color: c.text,
+            fontFamily: "Inter_500Medium",
+            marginTop: 2,
+          }}
+        >
+          {value}
+        </Text>
+      </View>
+    </View>
   );
 }
 
@@ -321,14 +493,23 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scroll: {
-    padding: 20,
-    paddingBottom: 40,
-    gap: 8,
+    padding: spacing.xl,
+    paddingBottom: spacing["3xl"],
+    gap: spacing.md,
+  },
+  stepperWrap: {
+    paddingHorizontal: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  card: {
+    padding: spacing.lg,
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    gap: spacing.md,
   },
   fieldLabel: {
-    fontWeight: "600",
-    marginBottom: 4,
-    marginTop: 8,
+    fontFamily: "Inter_600SemiBold",
+    fontSize: 13,
   },
   studentList: {
     borderWidth: 1,
@@ -337,13 +518,13 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   studentScroll: {
-    maxHeight: 280,
+    maxHeight: 300,
   },
   studentRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    paddingHorizontal: 12,
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
@@ -357,14 +538,14 @@ const styles = StyleSheet.create({
   dueDateRow: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: spacing.sm,
   },
   dateInput: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 8,
+    gap: spacing.sm,
     height: 44,
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
     borderRadius: radius.md,
     borderWidth: 1,
     flex: 1,
@@ -388,22 +569,45 @@ const styles = StyleSheet.create({
     minHeight: 80,
     borderWidth: 1,
     borderRadius: radius.md,
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
     paddingVertical: 10,
     fontSize: 14,
     fontFamily: "Inter_400Regular",
     textAlignVertical: "top",
   },
+  previewTitle: {
+    fontFamily: "Inter_700Bold",
+    fontSize: 14,
+  },
+  previewRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    paddingVertical: 10,
+  },
   errorBanner: {
-    padding: 12,
+    padding: spacing.md,
     borderRadius: radius.sm,
-    marginTop: 8,
+    marginTop: spacing.sm,
+  },
+  navRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  navBack: {
+    height: 44,
+    paddingHorizontal: spacing.lg,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
   },
   successContainer: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    padding: 20,
+    padding: spacing.xl,
   },
   successIcon: {
     width: 64,
@@ -411,6 +615,6 @@ const styles = StyleSheet.create({
     borderRadius: 32,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: 16,
+    marginBottom: spacing.lg,
   },
 });

--- a/packages/psychologist-mobapp/app/(screens)/diagnostics/test/[slug].tsx
+++ b/packages/psychologist-mobapp/app/(screens)/diagnostics/test/[slug].tsx
@@ -4,10 +4,22 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { testDefinitions } from "@tirek/shared";
-import { Text, Button } from "../../../../components/ui";
+import { Text, Button, HelpSheet } from "../../../../components/ui";
 import { useT, useLanguage } from "../../../../lib/hooks/useLanguage";
-import { useThemeColors, radius } from "../../../../lib/theme";
+import { useThemeColors, radius, spacing } from "../../../../lib/theme";
 import { hapticLight } from "../../../../lib/haptics";
+import { colors as ds } from "@tirek/shared/design-system";
+
+type IconName = keyof typeof Ionicons.glyphMap;
+
+function iconForSlug(slug: string): IconName {
+  if (slug.startsWith("phq")) return "sad-outline";
+  if (slug.startsWith("gad")) return "pulse-outline";
+  if (slug.startsWith("scared")) return "shield-half-outline";
+  if (slug.startsWith("rcads")) return "happy-outline";
+  if (slug.startsWith("sdq")) return "people-outline";
+  return "clipboard-outline";
+}
 
 export default function TestDetailScreen() {
   const t = useT();
@@ -16,7 +28,7 @@ export default function TestDetailScreen() {
   const router = useRouter();
   const { slug } = useLocalSearchParams<{ slug: string }>();
 
-  const [tipsOpen, setTipsOpen] = useState(false);
+  const [helpOpen, setHelpOpen] = useState(false);
 
   if (!slug || !(slug in testDefinitions)) {
     return (
@@ -61,145 +73,156 @@ export default function TestDetailScreen() {
     >
       <Stack.Screen options={{ title: t.psychologist.diagnostics }} />
       <ScrollView contentContainerStyle={styles.scroll}>
-        <Text variant="h2" style={{ fontWeight: "700" }}>
-          {name}
-        </Text>
-        <Text variant="body" style={{ marginTop: 6 }}>
-          {description}
-        </Text>
+        {/* Hero — brand-tinted */}
+        <View
+          style={[
+            styles.hero,
+            { backgroundColor: ds.brandSoft, borderColor: `${c.primary}1A` },
+          ]}
+        >
+          <View style={styles.heroRow}>
+            <View
+              style={[styles.heroIcon, { backgroundColor: c.surface }]}
+            >
+              <Ionicons
+                name={iconForSlug(td.slug)}
+                size={22}
+                color={c.primaryDark}
+              />
+            </View>
+            <View style={{ flex: 1, minWidth: 0 }}>
+              <Text
+                style={{
+                  fontSize: 20,
+                  lineHeight: 26,
+                  fontFamily: "Inter_700Bold",
+                  color: c.text,
+                }}
+              >
+                {name}
+              </Text>
+              <Text
+                variant="bodyLight"
+                style={{ marginTop: 4, lineHeight: 20 }}
+              >
+                {description}
+              </Text>
+            </View>
+          </View>
 
-        <View style={styles.metaRow}>
-          {td.durationMinutes != null && (
-            <View
-              style={[
-                styles.metaPill,
-                { backgroundColor: c.surfaceSecondary },
-              ]}
-            >
-              <Ionicons name="time-outline" size={12} color={c.textLight} />
-              <Text variant="caption">
-                {t.psychologist.testDurationMinutes.replace(
-                  "{n}",
-                  String(td.durationMinutes),
-                )}
+          <View style={styles.metaRow}>
+            {td.durationMinutes != null && (
+              <View
+                style={[styles.metaPill, { backgroundColor: c.surface }]}
+              >
+                <Ionicons name="time-outline" size={11} color={c.textLight} />
+                <Text style={[styles.metaPillText, { color: c.textLight }]}>
+                  {t.psychologist.testDurationMinutes.replace(
+                    "{n}",
+                    String(td.durationMinutes),
+                  )}
+                </Text>
+              </View>
+            )}
+            {td.ageRange && (
+              <View
+                style={[styles.metaPill, { backgroundColor: c.surface }]}
+              >
+                <Ionicons name="school-outline" size={11} color={c.textLight} />
+                <Text style={[styles.metaPillText, { color: c.textLight }]}>
+                  {t.psychologist.testAgeRangeGrades
+                    .replace("{from}", String(td.ageRange.minGrade))
+                    .replace("{to}", String(td.ageRange.maxGrade))}
+                </Text>
+              </View>
+            )}
+            <View style={[styles.metaPill, { backgroundColor: c.surface }]}>
+              <Ionicons
+                name="help-circle-outline"
+                size={11}
+                color={c.textLight}
+              />
+              <Text style={[styles.metaPillText, { color: c.textLight }]}>
+                {td.questions.length}{" "}
+                {language === "kz" ? "сұрақ" : "вопр."}
               </Text>
             </View>
-          )}
-          {td.ageRange && (
-            <View
-              style={[
-                styles.metaPill,
-                { backgroundColor: c.surfaceSecondary },
-              ]}
-            >
-              <Ionicons name="school-outline" size={12} color={c.textLight} />
-              <Text variant="caption">
-                {t.psychologist.testAgeRangeGrades
-                  .replace("{from}", String(td.ageRange.minGrade))
-                  .replace("{to}", String(td.ageRange.maxGrade))}
-              </Text>
-            </View>
-          )}
-          <View
-            style={[
-              styles.metaPill,
-              { backgroundColor: c.surfaceSecondary },
-            ]}
-          >
-            <Text variant="caption">
-              {td.questions.length}{" "}
-              {language === "kz" ? "сұрақ" : "вопр."}
-            </Text>
           </View>
         </View>
 
+        {/* Inline CTAs — primary fill + outlined secondary */}
+        <View style={styles.ctaCol}>
+          <Button
+            title={t.psychologist.assignToStudentBtn}
+            variant="primary"
+            size="md"
+            onPress={() => goAssign("student")}
+          />
+          <Pressable
+            onPress={() => goAssign("class")}
+            style={({ pressed }) => [
+              styles.outlineBtn,
+              { borderColor: c.primary, backgroundColor: "transparent" },
+              pressed && { opacity: 0.85 },
+            ]}
+            accessibilityRole="button"
+          >
+            <Text
+              style={{
+                fontFamily: "Inter_600SemiBold",
+                fontSize: 15,
+                color: c.primary,
+              }}
+            >
+              {t.psychologist.assignToClassBtn}
+            </Text>
+          </Pressable>
+        </View>
+
+        {/* When-to-assign tip — single-row trigger that opens HelpSheet */}
         {tips && (
-          <View
-            style={[
-              styles.tipsCard,
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setHelpOpen(true);
+            }}
+            style={({ pressed }) => [
+              styles.tipsTrigger,
               {
                 backgroundColor: c.surface,
                 borderColor: c.borderLight,
               },
+              pressed && { opacity: 0.85 },
             ]}
           >
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                setTipsOpen((v) => !v);
+            <Ionicons name="bulb-outline" size={16} color={c.warning} />
+            <Text
+              style={{
+                fontFamily: "Inter_600SemiBold",
+                fontSize: 13,
+                color: c.text,
+                flex: 1,
               }}
-              style={styles.tipsHeader}
             >
-              <Ionicons name="bulb-outline" size={18} color={c.warning} />
-              <Text
-                variant="body"
-                style={{
-                  fontWeight: "700",
-                  color: c.text,
-                  flex: 1,
-                }}
-              >
-                {t.psychologist.testWhenToAssign}
-              </Text>
-              <Ionicons
-                name={tipsOpen ? "chevron-up" : "chevron-down"}
-                size={18}
-                color={c.textLight}
-              />
-            </Pressable>
-            {tipsOpen && (
-              <Text
-                variant="body"
-                style={{
-                  color: c.text,
-                  marginTop: 10,
-                  lineHeight: 20,
-                }}
-              >
-                {tips}
-              </Text>
-            )}
-          </View>
+              {t.psychologist.testWhenToAssign}
+            </Text>
+            <Ionicons
+              name="chevron-forward"
+              size={14}
+              color={c.textLight}
+            />
+          </Pressable>
         )}
       </ScrollView>
 
-      <View
-        style={[
-          styles.footer,
-          { backgroundColor: c.bg, borderTopColor: c.borderLight },
-        ]}
-      >
-        {/* Primary CTA — brand fill, full-width */}
-        <Button
-          title={t.psychologist.assignToStudentBtn}
-          variant="primary"
-          size="md"
-          onPress={() => goAssign("student")}
+      {tips && (
+        <HelpSheet
+          visible={helpOpen}
+          title={t.psychologist.testWhenToAssign}
+          description={tips}
+          onClose={() => setHelpOpen(false)}
         />
-        {/* Secondary CTA — outline (transparent fill + brand border) */}
-        <Pressable
-          onPress={() => goAssign("class")}
-          style={({ pressed }) => [
-            styles.outlineBtn,
-            {
-              borderColor: c.primary,
-              backgroundColor: "transparent",
-            },
-            pressed && { opacity: 0.85 },
-          ]}
-          accessibilityRole="button"
-        >
-          <Text
-            style={{
-              fontFamily: "Inter_600SemiBold",
-              fontSize: 16,
-              color: c.primary,
-            }}
-          >
-            {t.psychologist.assignToClassBtn}
-          </Text>
-        </Pressable>
-      </View>
+      )}
     </SafeAreaView>
   );
 }
@@ -207,16 +230,38 @@ export default function TestDetailScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1 },
   scroll: {
-    paddingHorizontal: 20,
-    paddingTop: 16,
-    paddingBottom: 140,
-    gap: 4,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.lg,
+    paddingBottom: spacing["3xl"],
+    gap: spacing.lg,
+  },
+  hero: {
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    padding: spacing.lg,
+  },
+  heroRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: spacing.md,
+  },
+  heroIcon: {
+    width: 48,
+    height: 48,
+    borderRadius: radius.lg,
+    alignItems: "center",
+    justifyContent: "center",
+    shadowColor: "#000",
+    shadowOpacity: 0.06,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 },
+    elevation: 1,
   },
   metaRow: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 6,
-    marginTop: 12,
+    gap: spacing.sm,
+    marginTop: spacing.lg,
   },
   metaPill: {
     flexDirection: "row",
@@ -226,29 +271,13 @@ const styles = StyleSheet.create({
     paddingVertical: 4,
     borderRadius: 999,
   },
-  tipsCard: {
-    marginTop: 16,
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-    borderRadius: radius.lg,
-    borderWidth: 1,
+  metaPillText: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_500Medium",
   },
-  tipsHeader: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  footer: {
-    position: "absolute",
-    bottom: 0,
-    left: 0,
-    right: 0,
-    flexDirection: "column",
-    gap: 8,
-    paddingHorizontal: 20,
-    paddingTop: 12,
-    paddingBottom: 16,
-    borderTopWidth: 1,
+  ctaCol: {
+    gap: spacing.sm,
   },
   outlineBtn: {
     height: 50,
@@ -257,6 +286,15 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     alignSelf: "stretch",
+  },
+  tipsTrigger: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
   },
   empty: {
     flex: 1,

--- a/packages/psychologist-mobapp/app/(screens)/messages/[conversationId].tsx
+++ b/packages/psychologist-mobapp/app/(screens)/messages/[conversationId].tsx
@@ -13,16 +13,16 @@ import { Ionicons } from "@expo/vector-icons";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useT } from "../../../lib/hooks/useLanguage";
-import { Text, Body, Input, Button } from "../../../components/ui";
+import { Text, Body, Input, Button, DayDivider } from "../../../components/ui";
 import { SkeletonList } from "../../../components/Skeleton";
-import { useThemeColors } from "../../../lib/theme";
+import { useThemeColors, spacing } from "../../../lib/theme";
 import { colors as ds } from "@tirek/shared/design-system";
 import { directChatApi } from "../../../lib/api/direct-chat";
 import { useAuthStore } from "../../../lib/store/auth-store";
 import { hapticLight } from "../../../lib/haptics";
 import type { DirectMessage } from "@tirek/shared";
 
-const TIME_GROUP_GAP_MS = 5 * 60 * 1000; // 5 minutes
+const TIME_GROUP_GAP_MS = 5 * 60 * 1000;
 
 function formatMessageTime(dateStr: string) {
   return new Date(dateStr).toLocaleTimeString("ru-RU", {
@@ -31,42 +31,84 @@ function formatMessageTime(dateStr: string) {
   });
 }
 
-interface ChatItem {
-  type: "time" | "message";
-  // for time
-  timestamp?: string;
-  // for message
-  message?: DirectMessage;
-  showStatus?: boolean;
+function isSameDay(a: Date, b: Date) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
 }
 
-/**
- * Build flat list of chat items with sparse time separators.
- * A timestamp separator is inserted before the very first message and
- * before any message whose gap from the previous one exceeds 5 minutes.
- * Messages within a 5-minute window are grouped without timestamp.
- */
-function buildItems(messages: DirectMessage[], userId: string | undefined): ChatItem[] {
+function dayLabel(date: Date, todayLabel: string, yesterdayLabel: string) {
+  const now = new Date();
+  if (isSameDay(date, now)) return todayLabel;
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  if (isSameDay(date, yesterday)) return yesterdayLabel;
+  return date.toLocaleDateString("ru-RU", {
+    day: "numeric",
+    month: "long",
+  });
+}
+
+interface ChatItem {
+  type: "day" | "time" | "message";
+  dayLabel?: string;
+  timestamp?: string;
+  message?: DirectMessage;
+  showStatus?: boolean;
+  isFirstInGroup?: boolean;
+}
+
+function buildItems(
+  messages: DirectMessage[],
+  userId: string | undefined,
+  todayLabel: string,
+  yesterdayLabel: string,
+): ChatItem[] {
   const items: ChatItem[] = [];
+  let prevDate: Date | null = null;
   let prevTime = 0;
+
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
-    const t = new Date(msg.createdAt).getTime();
-    if (i === 0 || t - prevTime > TIME_GROUP_GAP_MS) {
+    const date = new Date(msg.createdAt);
+    const t = date.getTime();
+    const next = messages[i + 1];
+
+    // Day divider
+    if (!prevDate || !isSameDay(prevDate, date)) {
+      items.push({
+        type: "day",
+        dayLabel: dayLabel(date, todayLabel, yesterdayLabel),
+      });
+    }
+
+    // Time-separator on first-of-day OR after >5min gap
+    const newGroup =
+      !prevDate ||
+      !isSameDay(prevDate, date) ||
+      t - prevTime > TIME_GROUP_GAP_MS;
+
+    if (newGroup) {
       items.push({ type: "time", timestamp: msg.createdAt });
     }
-    // Show read-receipt only on the last "mine" message in a 5-min group.
-    const next = messages[i + 1];
+
     const isMine = msg.senderId === userId;
     const nextIsMineSameGroup =
       !!next &&
       next.senderId === userId &&
+      isSameDay(date, new Date(next.createdAt)) &&
       new Date(next.createdAt).getTime() - t <= TIME_GROUP_GAP_MS;
+
     items.push({
       type: "message",
       message: msg,
       showStatus: isMine && !nextIsMineSameGroup,
+      isFirstInGroup: newGroup,
     });
+
+    prevDate = date;
     prevTime = t;
   }
   return items;
@@ -112,9 +154,13 @@ export default function ChatScreen() {
 
   const conversation = convData?.data?.find((c) => c.id === conversationId);
   const messages = messagesData?.data ?? [];
-  const items = buildItems(messages, userId);
+  const items = buildItems(
+    messages,
+    userId,
+    t.directChat.today,
+    t.directChat.yesterday,
+  );
 
-  // Mark as read
   useEffect(() => {
     if (conversationId) {
       directChatApi.markRead(conversationId).then(() => {
@@ -128,7 +174,6 @@ export default function ChatScreen() {
     }
   }, [conversationId, messagesData]);
 
-  // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     if (items.length > 0) {
       setTimeout(() => {
@@ -159,6 +204,9 @@ export default function ChatScreen() {
   }
 
   function renderItem({ item }: { item: ChatItem }) {
+    if (item.type === "day") {
+      return <DayDivider label={item.dayLabel!} marginY="md" />;
+    }
     if (item.type === "time") {
       return (
         <View style={styles.timeSeparator}>
@@ -197,7 +245,6 @@ export default function ChatScreen() {
           >
             {msg.content}
           </Text>
-          {/* Read receipt only on last mine message in a group. */}
           {isMine && item.showStatus && (
             <View style={styles.statusRow}>
               <Ionicons
@@ -259,7 +306,11 @@ export default function ChatScreen() {
               ref={flatListRef}
               data={items}
               keyExtractor={(it, idx) =>
-                it.type === "message" ? `m-${it.message!.id}` : `t-${idx}`
+                it.type === "message"
+                  ? `m-${it.message!.id}`
+                  : it.type === "day"
+                  ? `d-${idx}`
+                  : `t-${idx}`
               }
               renderItem={renderItem}
               contentContainerStyle={styles.messagesList}
@@ -315,8 +366,8 @@ const styles = StyleSheet.create({
   chatHeader: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 10,
-    paddingHorizontal: 12,
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
     paddingVertical: 10,
     borderBottomWidth: 1,
   },
@@ -335,18 +386,19 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   messagesList: {
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    gap: 4,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: 3,
   },
   timeSeparator: {
     alignItems: "center",
-    paddingVertical: 8,
+    paddingVertical: 6,
   },
   timeSeparatorText: {
     fontSize: 11,
     lineHeight: 14,
-    fontFamily: "Inter_400Regular",
+    fontFamily: "Inter_500Medium",
   },
   bubbleRow: {
     flexDirection: "row",
@@ -358,16 +410,16 @@ const styles = StyleSheet.create({
     justifyContent: "flex-start",
   },
   bubble: {
-    maxWidth: "80%",
-    paddingHorizontal: 14,
-    paddingVertical: 10,
+    maxWidth: "82%",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
     borderRadius: 18,
   },
   bubbleMine: {
-    borderBottomRightRadius: 6,
+    borderBottomRightRadius: 4,
   },
   bubbleOther: {
-    borderBottomLeftRadius: 6,
+    borderBottomLeftRadius: 4,
   },
   statusRow: {
     flexDirection: "row",
@@ -378,8 +430,8 @@ const styles = StyleSheet.create({
   inputBar: {
     flexDirection: "row",
     alignItems: "flex-end",
-    gap: 8,
-    paddingHorizontal: 12,
+    gap: spacing.sm,
+    paddingHorizontal: spacing.md,
     paddingVertical: 10,
     borderTopWidth: 1,
   },

--- a/packages/psychologist-mobapp/app/(screens)/office-hours.tsx
+++ b/packages/psychologist-mobapp/app/(screens)/office-hours.tsx
@@ -4,12 +4,13 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Text, Card, Button, Body, H4 } from "../../components/ui";
+import { Text, Body } from "../../components/ui";
 import { useThemeColors, spacing, radius } from "../../lib/theme";
 import { officeHoursApi } from "../../lib/api/office-hours";
 import { useAuthStore } from "../../lib/store/auth-store";
 import { hapticLight } from "../../lib/haptics";
 import { isDayOff } from "@tirek/shared/office-hours";
+import { colors as ds } from "@tirek/shared/design-system";
 import type {
   OfficeHoursDayOfWeek,
   OfficeHoursInterval,
@@ -98,7 +99,6 @@ export default function OfficeHoursScreen() {
     return [...(overrides ?? [])].sort((a, b) => a.date.localeCompare(b.date));
   }, [overrides]);
 
-  // ── Sheets ────────────────────────────────────────────────────────────
   const [editingDow, setEditingDow] = useState<OfficeHoursDayOfWeek | null>(null);
   const [overrideMode, setOverrideMode] = useState<
     | { kind: "create" }
@@ -154,15 +154,31 @@ export default function OfficeHoursScreen() {
     <SafeAreaView style={{ flex: 1, backgroundColor: c.bg }} edges={["bottom"]}>
       <Stack.Screen options={{ title: "Расписание" }} />
       <ScrollView contentContainerStyle={styles.container}>
-        {/* ── Шаблон недели ───────────────────────────────────────── */}
-        <H4>Шаблон недели</H4>
+        {/* ── Today / tomorrow preview ──────────────────────────── */}
+        <View style={styles.previewRow}>
+          <PreviewCard label="Сегодня" resolved={todayResolved} c={c} />
+          <PreviewCard label="Завтра" resolved={tomorrowResolved} c={c} />
+        </View>
+
+        {/* ── Weekly grid ───────────────────────────────────────── */}
+        <Text style={[styles.sectionEyebrow, { color: c.textLight }]}>
+          Шаблон недели
+        </Text>
         {loadingTemplate ? (
-          <Body style={{ color: c.textLight }}>Загрузка…</Body>
+          <View
+            style={[
+              styles.loadingBox,
+              { backgroundColor: c.surface, borderColor: c.borderLight },
+            ]}
+          >
+            <Body style={{ color: c.textLight }}>Загрузка…</Body>
+          </View>
         ) : (
-          <Card style={styles.templateCard}>
-            {([1, 2, 3, 4, 5, 6, 7] as OfficeHoursDayOfWeek[]).map((dow, i) => {
+          <View style={styles.weekGrid}>
+            {([1, 2, 3, 4, 5, 6, 7] as OfficeHoursDayOfWeek[]).map((dow) => {
               const row = templateByDow.get(dow);
               const intervals = row?.intervals ?? [];
+              const off = isDayOff(intervals);
               return (
                 <Pressable
                   key={dow}
@@ -171,98 +187,184 @@ export default function OfficeHoursScreen() {
                     setEditingDow(dow);
                   }}
                   style={({ pressed }) => [
-                    styles.dowRow,
-                    i < 6 && { borderBottomWidth: 1, borderBottomColor: c.borderLight },
-                    pressed && { opacity: 0.6 },
+                    styles.dayCell,
+                    {
+                      backgroundColor: off ? c.surfaceSecondary : c.surface,
+                      borderColor: off ? c.borderLight : `${c.primary}26`,
+                    },
+                    pressed && { opacity: 0.85 },
                   ]}
                 >
-                  <Body style={styles.dowLabel}>{DOW_LABELS[dow]}</Body>
-                  <Text
-                    style={[
-                      styles.dowValue,
-                      { color: isDayOff(intervals) ? c.textLight : c.text },
-                    ]}
-                  >
-                    {formatIntervals(intervals)}
-                  </Text>
-                  <Ionicons name="pencil-outline" size={18} color={c.textLight} />
+                  <View style={styles.dayCellHeader}>
+                    <Text
+                      style={[
+                        styles.dayCellLabel,
+                        { color: off ? c.textLight : c.primaryDark },
+                      ]}
+                    >
+                      {DOW_LABELS[dow]}
+                    </Text>
+                    <Ionicons
+                      name="pencil-outline"
+                      size={11}
+                      color={c.textLight}
+                    />
+                  </View>
+                  {off ? (
+                    <Text
+                      style={[styles.dayCellOff, { color: c.textLight }]}
+                    >
+                      выходной
+                    </Text>
+                  ) : (
+                    <View style={{ gap: 2 }}>
+                      {intervals.map((iv, i) => (
+                        <Text
+                          key={i}
+                          style={[styles.dayCellInterval, { color: c.text }]}
+                        >
+                          {iv.start}–{iv.end}
+                        </Text>
+                      ))}
+                    </View>
+                  )}
+                  {row?.notes ? (
+                    <Text
+                      style={[styles.dayCellNotes, { color: c.textLight }]}
+                      numberOfLines={1}
+                    >
+                      {row.notes}
+                    </Text>
+                  ) : null}
                 </Pressable>
               );
             })}
-          </Card>
+          </View>
         )}
 
-        {/* ── Исключения ──────────────────────────────────────────── */}
-        <H4 style={{ marginTop: spacing.md }}>Исключения</H4>
-        <Text variant="caption" style={{ color: c.textLight }}>
-          Ближайшие 4 недели
-        </Text>
+        {/* ── Overrides ─────────────────────────────────────────── */}
+        <View style={styles.overridesHeader}>
+          <View style={{ flex: 1 }}>
+            <Text style={[styles.sectionEyebrow, { color: c.textLight }]}>
+              Исключения
+            </Text>
+            <Text style={[styles.sectionSubtitle, { color: c.textLight }]}>
+              Ближайшие 4 недели
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setOverrideMode({ kind: "create" });
+            }}
+            style={({ pressed }) => [
+              styles.addBtn,
+              { backgroundColor: c.primary },
+              pressed && { opacity: 0.9 },
+            ]}
+          >
+            <Ionicons name="add" size={14} color="#FFF" />
+            <Text style={styles.addBtnText}>Добавить</Text>
+          </Pressable>
+        </View>
+
         {sortedOverrides.length === 0 ? (
-          <Body style={{ color: c.textLight }}>Исключений нет.</Body>
+          <View
+            style={[
+              styles.emptyOverrides,
+              { backgroundColor: c.surface, borderColor: c.borderLight },
+            ]}
+          >
+            <View
+              style={[
+                styles.emptyIconWrap,
+                { backgroundColor: c.surfaceSecondary },
+              ]}
+            >
+              <Ionicons
+                name="calendar-outline"
+                size={18}
+                color={c.textLight}
+              />
+            </View>
+            <Body style={{ color: c.textLight, marginTop: 6 }}>
+              Исключений нет
+            </Body>
+          </View>
         ) : (
-          <Card style={styles.overridesCard}>
-            {sortedOverrides.map((ov: OfficeHoursOverrideEntry, i) => (
-              <View
-                key={ov.id}
-                style={[
-                  styles.overrideRow,
-                  i < sortedOverrides.length - 1 && {
-                    borderBottomWidth: 1,
-                    borderBottomColor: c.borderLight,
-                  },
-                ]}
-              >
-                <Pressable
-                  style={{ flex: 1 }}
-                  onPress={() => {
-                    hapticLight();
-                    setOverrideMode({
-                      kind: "edit",
-                      date: ov.date,
-                      intervals: ov.intervals,
-                      notes: ov.notes,
-                    });
-                  }}
+          <View
+            style={[
+              styles.overridesList,
+              { backgroundColor: c.surface, borderColor: c.borderLight },
+            ]}
+          >
+            {sortedOverrides.map((ov: OfficeHoursOverrideEntry, i) => {
+              const off = isDayOff(ov.intervals);
+              return (
+                <View
+                  key={ov.id}
+                  style={[
+                    styles.overrideRow,
+                    i < sortedOverrides.length - 1 && {
+                      borderBottomWidth: 1,
+                      borderBottomColor: c.borderLight,
+                    },
+                  ]}
                 >
-                  <Body style={styles.overrideDate}>{formatHumanDate(ov.date)}</Body>
-                  <Text style={{ color: c.textLight }}>
-                    {formatIntervals(ov.intervals)}
-                    {ov.notes ? ` · ${ov.notes}` : ""}
-                  </Text>
-                </Pressable>
-                <Pressable
-                  onPress={() => {
-                    hapticLight();
-                    deleteOverrideMut.mutate(ov.date);
-                  }}
-                  hitSlop={8}
-                  style={({ pressed }) => [pressed && { opacity: 0.6 }]}
-                >
-                  <Ionicons name="close" size={20} color={c.textLight} />
-                </Pressable>
-              </View>
-            ))}
-          </Card>
+                  <Pressable
+                    style={{ flex: 1 }}
+                    onPress={() => {
+                      hapticLight();
+                      setOverrideMode({
+                        kind: "edit",
+                        date: ov.date,
+                        intervals: ov.intervals,
+                        notes: ov.notes,
+                      });
+                    }}
+                  >
+                    <Text
+                      style={{
+                        fontSize: 14,
+                        fontFamily: "Inter_600SemiBold",
+                        color: c.text,
+                      }}
+                    >
+                      {formatHumanDate(ov.date)}
+                    </Text>
+                    <Text
+                      style={[
+                        styles.overrideMeta,
+                        {
+                          color: c.textLight,
+                          fontStyle: off ? "italic" : "normal",
+                        },
+                      ]}
+                    >
+                      {formatIntervals(ov.intervals)}
+                      {ov.notes ? ` · ${ov.notes}` : ""}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      hapticLight();
+                      deleteOverrideMut.mutate(ov.date);
+                    }}
+                    hitSlop={8}
+                    style={({ pressed }) => [
+                      styles.deleteBtn,
+                      pressed && { opacity: 0.6 },
+                    ]}
+                  >
+                    <Ionicons name="close" size={16} color={c.textLight} />
+                  </Pressable>
+                </View>
+              );
+            })}
+          </View>
         )}
-        <Button
-          title="+ Добавить исключение"
-          variant="secondary"
-          onPress={() => {
-            hapticLight();
-            setOverrideMode({ kind: "create" });
-          }}
-        />
-
-        {/* ── Превью ──────────────────────────────────────────────── */}
-        <H4 style={{ marginTop: spacing.md }}>Превью</H4>
-        <Card style={styles.previewCard}>
-          <PreviewLine label="Сегодня" resolved={todayResolved} colors={c} />
-          <View style={{ height: 1, backgroundColor: c.borderLight, marginVertical: 8 }} />
-          <PreviewLine label="Завтра" resolved={tomorrowResolved} colors={c} />
-        </Card>
       </ScrollView>
 
-      {/* ── Bottom sheets ─────────────────────────────────────────── */}
       {editingDow != null ? (
         <IntervalsEditorSheet
           open={editingDow != null}
@@ -294,31 +396,85 @@ export default function OfficeHoursScreen() {
   );
 }
 
-function PreviewLine({
+function PreviewCard({
   label,
   resolved,
-  colors,
+  c,
 }: {
   label: string;
   resolved: OfficeHoursResolved | undefined;
-  colors: ReturnType<typeof useThemeColors>;
+  c: ReturnType<typeof useThemeColors>;
 }) {
-  if (!resolved) {
-    return (
-      <Text style={{ color: colors.textLight }}>
-        {label}: <Text style={{ color: colors.textLight }}>загрузка…</Text>
-      </Text>
-    );
-  }
-  const offDay = isDayOff(resolved.intervals);
+  const off = resolved ? isDayOff(resolved.intervals) : false;
   return (
-    <View>
-      <Text style={{ color: colors.textLight }}>
-        <Text style={{ color: colors.text, fontWeight: "600" }}>{label}: </Text>
-        {offDay ? "выходной" : `работает ${formatIntervals(resolved.intervals)}`}
+    <View
+      style={[
+        styles.previewCard,
+        {
+          backgroundColor: !resolved
+            ? c.surface
+            : off
+              ? c.surfaceSecondary
+              : ds.brandSoft,
+          borderColor: !resolved
+            ? c.borderLight
+            : off
+              ? c.borderLight
+              : `${c.primary}26`,
+        },
+      ]}
+    >
+      <Text
+        style={[styles.previewLabel, { color: c.textLight }]}
+      >
+        {label}
       </Text>
-      {resolved.notes ? (
-        <Text variant="bodyXs" style={{ color: colors.textLight, marginTop: 2 }}>
+      {!resolved ? (
+        <Text
+          style={{
+            fontSize: 13,
+            color: c.textLight,
+            marginTop: 4,
+          }}
+        >
+          загрузка…
+        </Text>
+      ) : off ? (
+        <Text
+          style={{
+            fontSize: 13,
+            color: c.textLight,
+            fontStyle: "italic",
+            marginTop: 4,
+          }}
+        >
+          выходной
+        </Text>
+      ) : (
+        <Text
+          style={{
+            fontSize: 16,
+            lineHeight: 22,
+            fontFamily: "Inter_700Bold",
+            color: c.text,
+            marginTop: 4,
+            fontVariant: ["tabular-nums"],
+          }}
+        >
+          {formatIntervals(resolved.intervals)}
+        </Text>
+      )}
+      {resolved?.notes ? (
+        <Text
+          style={{
+            fontSize: 11,
+            lineHeight: 14,
+            color: c.textLight,
+            fontStyle: "italic",
+            marginTop: 2,
+          }}
+          numberOfLines={1}
+        >
           {resolved.notes}
         </Text>
       ) : null}
@@ -329,31 +485,122 @@ function PreviewLine({
 const styles = StyleSheet.create({
   container: {
     padding: spacing.md,
+    paddingBottom: spacing["3xl"],
+    gap: spacing.md,
+  },
+  previewRow: {
+    flexDirection: "row",
     gap: spacing.sm,
   },
-  templateCard: {
-    padding: 0,
-    borderRadius: radius.md,
-    overflow: "hidden",
+  previewCard: {
+    flex: 1,
+    padding: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
   },
-  dowRow: {
+  previewLabel: {
+    fontSize: 11,
+    lineHeight: 14,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    fontFamily: "Inter_600SemiBold",
+  },
+  sectionEyebrow: {
+    fontSize: 11,
+    lineHeight: 14,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    fontFamily: "Inter_600SemiBold",
+    marginTop: spacing.sm,
+  },
+  sectionSubtitle: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_400Regular",
+    marginTop: 2,
+  },
+  loadingBox: {
+    padding: spacing.lg,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    alignItems: "center",
+  },
+  weekGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.sm,
+  },
+  dayCell: {
+    width: "47.5%",
+    padding: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    minHeight: 76,
+  },
+  dayCellHeader: {
     flexDirection: "row",
     alignItems: "center",
-    paddingHorizontal: spacing.md,
-    paddingVertical: 14,
-    gap: spacing.sm,
+    justifyContent: "space-between",
+    marginBottom: 6,
   },
-  dowLabel: {
-    width: 28,
-    fontWeight: "600",
+  dayCellLabel: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_700Bold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
   },
-  dowValue: {
-    flex: 1,
+  dayCellOff: {
+    fontSize: 12,
+    fontStyle: "italic",
+  },
+  dayCellInterval: {
+    fontSize: 12,
+    lineHeight: 16,
+    fontFamily: "Inter_600SemiBold",
     fontVariant: ["tabular-nums"],
   },
-  overridesCard: {
-    padding: 0,
+  dayCellNotes: {
+    fontSize: 10,
+    lineHeight: 12,
+    fontStyle: "italic",
+    marginTop: 4,
+  },
+  overridesHeader: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: spacing.sm,
+  },
+  addBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 8,
     borderRadius: radius.md,
+  },
+  addBtnText: {
+    fontSize: 12,
+    fontFamily: "Inter_600SemiBold",
+    color: "#FFF",
+  },
+  emptyOverrides: {
+    paddingVertical: spacing.lg,
+    paddingHorizontal: spacing.md,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    alignItems: "center",
+  },
+  emptyIconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  overridesList: {
+    borderRadius: radius.lg,
+    borderWidth: 1,
     overflow: "hidden",
   },
   overrideRow: {
@@ -363,11 +610,16 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     gap: spacing.sm,
   },
-  overrideDate: {
-    fontWeight: "600",
+  overrideMeta: {
+    fontSize: 12,
+    lineHeight: 16,
+    marginTop: 2,
   },
-  previewCard: {
-    padding: spacing.md,
+  deleteBtn: {
+    width: 28,
+    height: 28,
     borderRadius: radius.md,
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/packages/psychologist-mobapp/app/(screens)/profile.tsx
+++ b/packages/psychologist-mobapp/app/(screens)/profile.tsx
@@ -11,12 +11,12 @@ import { useRouter, Stack } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Constants from "expo-constants";
-import { Text, Card, Button, Input, Body, H2, H3 } from "../../components/ui";
+import { Text, Button, Input, Body } from "../../components/ui";
 import { ConfirmDialog } from "../../components/ConfirmDialog";
 import { useT, useLanguage } from "../../lib/hooks/useLanguage";
 import { useAuthStore } from "../../lib/store/auth-store";
 import { authApi } from "../../lib/api/auth";
-import { useThemeColors, radius } from "../../lib/theme";
+import { useThemeColors, radius, spacing } from "../../lib/theme";
 import { colors as ds } from "@tirek/shared/design-system";
 import { checkForUpdate } from "../../lib/updates";
 import { hapticLight } from "../../lib/haptics";
@@ -63,163 +63,286 @@ export default function ProfileScreen() {
         style={{ flex: 1 }}
         behavior={Platform.OS === "ios" ? "padding" : "height"}
       >
-      <ScrollView
-        contentContainerStyle={styles.scroll}
-        showsVerticalScrollIndicator={false}
-        keyboardShouldPersistTaps="handled"
-        style={{ backgroundColor: c.bg }}
-      >
-        {/* User card */}
-        {!editing ? (
-          <Card variant="floating" style={styles.userCard}>
-            <View style={[styles.avatarWrap, { backgroundColor: ds.brandSoft }]}>
-              <Ionicons name="person" size={36} color={c.primaryDark} />
-            </View>
-            <H2 style={styles.userName}>{user?.name}</H2>
-            <Body style={{ color: c.textLight }}>{user?.email}</Body>
-            <View style={[styles.roleBadge, { backgroundColor: ds.brandSoft }]}>
-              <Text style={{ fontSize: 12, fontWeight: "700", color: c.primaryDark }}>
-                {t.psychologist.role}
-              </Text>
-            </View>
-            <Pressable
-              onPress={startEdit}
-              style={({ pressed }) => [
-                styles.editBtn,
-                { backgroundColor: ds.brandSoft },
-                pressed && { opacity: 0.8 },
-              ]}
-            >
-              <Ionicons name="pencil" size={14} color={c.primaryDark} />
-              <Text style={{ fontSize: 14, fontWeight: "700", color: c.primaryDark }}>
-                {t.common.edit}
-              </Text>
-            </Pressable>
-          </Card>
-        ) : (
-          <Card variant="floating" style={styles.editCard}>
-            <H3 style={{ marginBottom: 16 }}>{t.common.edit}</H3>
-
-            <Text variant="caption" style={{ marginBottom: 6 }}>
-              {t.auth.name}
-            </Text>
-            <Input value={editName} onChangeText={setEditName} />
-
-            <View style={styles.editActions}>
-              <Button
-                title={t.common.cancel}
-                variant="secondary"
-                onPress={() => setEditing(false)}
-                size="md"
-                style={{ flex: 1 }}
-              />
-              <Button
-                title={t.common.save}
-                variant="primary"
-                onPress={() => saveMutation.mutate()}
-                disabled={saveMutation.isPending || !editName.trim()}
-                loading={saveMutation.isPending}
-                size="md"
-                style={{ flex: 1 }}
-              />
-            </View>
-          </Card>
-        )}
-
-        {/* My schedule */}
-        <Pressable
-          onPress={() => {
-            hapticLight();
-            router.push("/(screens)/office-hours");
-          }}
-          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          style={{ backgroundColor: c.bg }}
         >
-          <Card style={styles.sectionCard}>
-            <View style={styles.scheduleRow}>
-              <View style={[styles.sectionIcon, { backgroundColor: ds.brandSoft }]}>
-                <Ionicons name="calendar-outline" size={18} color={c.primaryDark} />
+          {/* Identity hero */}
+          {!editing ? (
+            <View style={styles.hero}>
+              <View
+                style={[styles.avatarWrap, { backgroundColor: ds.brandSoft }]}
+              >
+                <Ionicons name="person" size={36} color={c.primaryDark} />
               </View>
-              <Body style={{ fontWeight: "700", flex: 1 }}>
-                {t.officeHours.pageTitle}
-              </Body>
-              <Ionicons name="chevron-forward" size={18} color={c.textLight} />
-            </View>
-          </Card>
-        </Pressable>
-
-        {/* Language switcher */}
-        <Card style={styles.sectionCard}>
-          <View style={styles.sectionHeader}>
-            <View style={[styles.sectionIcon, { backgroundColor: ds.brandSoft }]}>
-              <Ionicons name="globe-outline" size={18} color={c.primaryDark} />
-            </View>
-            <Body style={{ fontWeight: "700", flex: 1 }}>
-              {t.profile.language}
-            </Body>
-          </View>
-          <View style={styles.langBtns}>
-            {(["ru", "kz"] as Language[]).map((lang) => (
-              <Pressable
-                key={lang}
-                onPress={() => setLanguage(lang)}
-                style={[
-                  styles.langBtn,
-                  {
-                    backgroundColor:
-                      language === lang ? c.primary : c.surfaceSecondary,
-                  },
-                ]}
+              <Text
+                style={{
+                  fontSize: 20,
+                  lineHeight: 26,
+                  fontFamily: "Inter_700Bold",
+                  color: c.text,
+                  marginTop: spacing.md,
+                }}
+              >
+                {user?.name}
+              </Text>
+              <Text
+                style={{
+                  fontSize: 13,
+                  lineHeight: 18,
+                  color: c.textLight,
+                  marginTop: 2,
+                }}
+              >
+                {user?.email}
+              </Text>
+              <View
+                style={[styles.roleBadge, { backgroundColor: ds.brandSoft }]}
               >
                 <Text
                   style={{
-                    fontSize: 14,
-                    fontWeight: "700",
-                    color: language === lang ? "#FFFFFF" : c.textLight,
+                    fontSize: 11,
+                    fontFamily: "Inter_700Bold",
+                    color: c.primaryDark,
+                    textTransform: "uppercase",
+                    letterSpacing: 0.6,
                   }}
                 >
-                  {lang === "ru" ? "Русский" : "Қазақша"}
+                  {t.psychologist.role}
+                </Text>
+              </View>
+              <Pressable
+                onPress={startEdit}
+                style={({ pressed }) => [
+                  styles.editBtn,
+                  { borderColor: c.borderLight },
+                  pressed && { opacity: 0.8 },
+                ]}
+              >
+                <Ionicons name="pencil-outline" size={14} color={c.text} />
+                <Text
+                  style={{
+                    fontSize: 13,
+                    fontFamily: "Inter_600SemiBold",
+                    color: c.text,
+                  }}
+                >
+                  {t.common.edit}
                 </Text>
               </Pressable>
-            ))}
-          </View>
-        </Card>
-
-        {/* App version & updates */}
-        <Card style={styles.sectionCard}>
-          <View style={styles.versionRow}>
-            <View style={{ flex: 1 }}>
-              <Body style={{ fontWeight: "600" }}>{t.common.appName}</Body>
-              <Text variant="bodyXs" style={{ color: c.textLight, marginTop: 2 }}>
-                v{Constants.expoConfig?.version ?? "1.0.0"}
-              </Text>
             </View>
+          ) : (
+            <View
+              style={[
+                styles.editCard,
+                { backgroundColor: c.surface, borderColor: c.borderLight },
+              ]}
+            >
+              <Text style={[styles.editTitle, { color: c.text }]}>
+                {t.common.edit}
+              </Text>
+              <Text
+                style={[styles.fieldLabel, { color: c.textLight }]}
+              >
+                {t.auth.name}
+              </Text>
+              <Input value={editName} onChangeText={setEditName} />
+              <View style={styles.editActions}>
+                <Button
+                  title={t.common.cancel}
+                  variant="secondary"
+                  onPress={() => setEditing(false)}
+                  size="md"
+                  style={{ flex: 1 }}
+                />
+                <Button
+                  title={t.common.save}
+                  variant="primary"
+                  onPress={() => saveMutation.mutate()}
+                  disabled={saveMutation.isPending || !editName.trim()}
+                  loading={saveMutation.isPending}
+                  size="md"
+                  style={{ flex: 1 }}
+                />
+              </View>
+            </View>
+          )}
+
+          {/* Settings list */}
+          <Text style={[styles.sectionEyebrow, { color: c.textLight }]}>
+            {t.profile.title}
+          </Text>
+          <View
+            style={[
+              styles.settingsCard,
+              { backgroundColor: c.surface, borderColor: c.borderLight },
+            ]}
+          >
             <Pressable
               onPress={() => {
                 hapticLight();
-                checkForUpdate();
+                router.push("/(screens)/office-hours");
               }}
               style={({ pressed }) => [
-                styles.updateBtn,
-                { backgroundColor: ds.brandSoft },
+                styles.row,
+                { borderBottomColor: c.borderLight, borderBottomWidth: 1 },
                 pressed && { opacity: 0.7 },
               ]}
             >
-              <Ionicons name="cloud-download-outline" size={16} color={c.primary} />
-              <Text variant="bodyXs" style={{ color: c.primary, fontWeight: "600" }}>
-                {t.profile.update}
-              </Text>
+              <View
+                style={[styles.rowIcon, { backgroundColor: ds.brandSoft }]}
+              >
+                <Ionicons
+                  name="calendar-outline"
+                  size={18}
+                  color={c.primaryDark}
+                />
+              </View>
+              <Body style={{ fontFamily: "Inter_600SemiBold", flex: 1 }}>
+                {t.officeHours.pageTitle}
+              </Body>
+              <Ionicons
+                name="chevron-forward"
+                size={16}
+                color={c.textLight}
+              />
             </Pressable>
-          </View>
-        </Card>
 
-        {/* Logout */}
-        <Button
-          title={t.auth.logout}
-          variant="danger"
-          onPress={() => setShowLogout(true)}
-          style={styles.logoutBtn}
-        />
-      </ScrollView>
+            <View
+              style={[
+                styles.row,
+                { borderBottomColor: c.borderLight, borderBottomWidth: 1 },
+              ]}
+            >
+              <View
+                style={[styles.rowIcon, { backgroundColor: ds.brandSoft }]}
+              >
+                <Ionicons
+                  name="globe-outline"
+                  size={18}
+                  color={c.primaryDark}
+                />
+              </View>
+              <Body style={{ fontFamily: "Inter_600SemiBold", flex: 1 }}>
+                {t.profile.language}
+              </Body>
+              <View style={styles.langBtns}>
+                {(["ru", "kz"] as Language[]).map((lang) => (
+                  <Pressable
+                    key={lang}
+                    onPress={() => {
+                      hapticLight();
+                      setLanguage(lang);
+                    }}
+                    style={[
+                      styles.langBtn,
+                      {
+                        backgroundColor:
+                          language === lang
+                            ? c.primary
+                            : c.surfaceSecondary,
+                      },
+                    ]}
+                  >
+                    <Text
+                      style={{
+                        fontSize: 12,
+                        fontFamily: "Inter_700Bold",
+                        color:
+                          language === lang ? "#FFFFFF" : c.textLight,
+                      }}
+                    >
+                      {lang === "ru" ? "RU" : "KZ"}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            <View style={styles.row}>
+              <View
+                style={[styles.rowIcon, { backgroundColor: ds.brandSoft }]}
+              >
+                <Ionicons
+                  name="information-circle-outline"
+                  size={18}
+                  color={c.primaryDark}
+                />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Body style={{ fontFamily: "Inter_600SemiBold" }}>
+                  {t.common.appName}
+                </Body>
+                <Text
+                  style={{
+                    fontSize: 11,
+                    lineHeight: 14,
+                    color: c.textLight,
+                    marginTop: 2,
+                  }}
+                >
+                  v{Constants.expoConfig?.version ?? "1.0.0"}
+                </Text>
+              </View>
+              <Pressable
+                onPress={() => {
+                  hapticLight();
+                  checkForUpdate();
+                }}
+                style={({ pressed }) => [
+                  styles.updateBtn,
+                  { borderColor: c.borderLight },
+                  pressed && { opacity: 0.7 },
+                ]}
+              >
+                <Ionicons
+                  name="cloud-download-outline"
+                  size={14}
+                  color={c.text}
+                />
+                <Text
+                  style={{
+                    fontSize: 12,
+                    fontFamily: "Inter_600SemiBold",
+                    color: c.text,
+                  }}
+                >
+                  {t.profile.update}
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+
+          {/* Logout — at the bottom, danger-styled */}
+          <View style={{ height: spacing.lg }} />
+          <Pressable
+            onPress={() => setShowLogout(true)}
+            style={({ pressed }) => [
+              styles.dangerRow,
+              {
+                backgroundColor: c.surface,
+                borderColor: `${c.danger}33`,
+              },
+              pressed && { opacity: 0.85 },
+            ]}
+          >
+            <View
+              style={[styles.rowIcon, { backgroundColor: `${c.danger}1A` }]}
+            >
+              <Ionicons name="log-out-outline" size={18} color={c.danger} />
+            </View>
+            <Body style={{ fontFamily: "Inter_600SemiBold", flex: 1, color: c.danger }}>
+              {t.auth.logout}
+            </Body>
+            <Ionicons
+              name="chevron-forward"
+              size={16}
+              color={c.danger}
+            />
+          </Pressable>
+        </ScrollView>
       </KeyboardAvoidingView>
 
       <ConfirmDialog
@@ -237,67 +360,88 @@ export default function ProfileScreen() {
 
 const styles = StyleSheet.create({
   scroll: {
-    paddingHorizontal: 20,
-    paddingBottom: 32,
-    paddingTop: 12,
+    paddingHorizontal: spacing.xl,
+    paddingBottom: spacing["3xl"],
+    paddingTop: spacing.md,
   },
 
-  // User card
-  userCard: {
+  // Identity hero
+  hero: {
     alignItems: "center",
-    paddingVertical: 28,
+    paddingVertical: spacing.lg,
   },
   avatarWrap: {
-    width: 72,
-    height: 72,
-    borderRadius: radius.lg,
+    width: 80,
+    height: 80,
+    borderRadius: radius.xl,
     alignItems: "center",
     justifyContent: "center",
   },
-  userName: {
-    marginTop: 16,
-  },
   roleBadge: {
-    marginTop: 8,
+    marginTop: 10,
     borderRadius: radius.full,
-    paddingHorizontal: 12,
+    paddingHorizontal: 10,
     paddingVertical: 4,
   },
   editBtn: {
     flexDirection: "row",
     alignItems: "center",
     gap: 6,
-    marginTop: 20,
+    marginTop: spacing.lg,
     borderRadius: radius.md,
-    paddingHorizontal: 20,
-    paddingVertical: 10,
+    borderWidth: 1,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 8,
   },
 
   // Edit card
   editCard: {
-    marginBottom: 0,
+    padding: spacing.lg,
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    gap: spacing.sm,
+  },
+  editTitle: {
+    fontSize: 16,
+    fontFamily: "Inter_700Bold",
+    marginBottom: spacing.sm,
+  },
+  fieldLabel: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
   },
   editActions: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 24,
+    gap: spacing.md,
+    marginTop: spacing.md,
   },
 
   // Sections
-  sectionCard: {
-    marginTop: 16,
+  sectionEyebrow: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
   },
-  sectionHeader: {
+  settingsCard: {
+    borderRadius: radius.xl,
+    borderWidth: 1,
+    overflow: "hidden",
+  },
+  row: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 12,
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 14,
   },
-  scheduleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 12,
-  },
-  sectionIcon: {
+  rowIcon: {
     width: 36,
     height: 36,
     borderRadius: radius.md,
@@ -305,36 +449,36 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
 
-  // Language
   langBtns: {
     flexDirection: "row",
-    gap: 8,
-    marginTop: 14,
+    gap: 4,
   },
   langBtn: {
-    flex: 1,
-    borderRadius: radius.md,
-    paddingVertical: 10,
+    width: 36,
+    height: 28,
+    borderRadius: radius.sm,
     alignItems: "center",
+    justifyContent: "center",
   },
 
-  // Version
-  versionRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-  },
   updateBtn: {
     flexDirection: "row",
     alignItems: "center",
-    gap: 6,
+    gap: 4,
     borderRadius: radius.md,
-    paddingHorizontal: 14,
-    paddingVertical: 8,
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
   },
 
-  // Logout
-  logoutBtn: {
-    marginTop: 16,
+  // Danger
+  dangerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 14,
+    borderRadius: radius.xl,
+    borderWidth: 1,
   },
 });

--- a/packages/psychologist-mobapp/components/ConfirmDialog.tsx
+++ b/packages/psychologist-mobapp/components/ConfirmDialog.tsx
@@ -1,7 +1,8 @@
 import { View, Modal, Pressable, StyleSheet } from "react-native";
-import { Text, Button } from "./ui";
+import { Ionicons } from "@expo/vector-icons";
+import { Text } from "./ui";
 import { useT } from "../lib/hooks/useLanguage";
-import { useThemeColors, radius } from "../lib/theme";
+import { useThemeColors, radius, spacing } from "../lib/theme";
 
 interface ConfirmDialogProps {
   open: boolean;
@@ -25,6 +26,13 @@ export function ConfirmDialog({
   const t = useT();
   const c = useThemeColors();
 
+  const isDanger = variant === "danger";
+  const accent = isDanger ? c.danger : c.primary;
+  const accentSoft = isDanger ? `${c.danger}1A` : `${c.primary}1A`;
+  const icon: keyof typeof Ionicons.glyphMap = isDanger
+    ? "alert-circle-outline"
+    : "help-circle-outline";
+
   return (
     <Modal
       visible={open}
@@ -35,8 +43,30 @@ export function ConfirmDialog({
       <View style={styles.overlay}>
         <Pressable style={styles.backdrop} onPress={onCancel} />
         <View style={[styles.dialog, { backgroundColor: c.surface }]}>
-          <Text variant="h3">{title ?? t.common.confirmDelete}</Text>
-          <Text variant="bodyLight" style={styles.desc}>
+          <View style={[styles.iconWrap, { backgroundColor: accentSoft }]}>
+            <Ionicons name={icon} size={24} color={accent} />
+          </View>
+          <Text
+            style={{
+              fontSize: 18,
+              lineHeight: 24,
+              fontFamily: "Inter_700Bold",
+              color: c.text,
+              textAlign: "center",
+              marginTop: spacing.md,
+            }}
+          >
+            {title ?? t.common.confirmDelete}
+          </Text>
+          <Text
+            style={{
+              fontSize: 14,
+              lineHeight: 20,
+              color: c.textLight,
+              textAlign: "center",
+              marginTop: 6,
+            }}
+          >
             {description ?? t.common.confirmDeleteDescription}
           </Text>
           <View style={styles.actions}>
@@ -44,11 +74,17 @@ export function ConfirmDialog({
               onPress={onCancel}
               style={({ pressed }) => [
                 styles.cancelBtn,
-                { borderColor: c.border },
+                { borderColor: c.borderLight },
                 pressed && { opacity: 0.85 },
               ]}
             >
-              <Text style={{ fontSize: 14, fontWeight: "700", color: c.text }}>
+              <Text
+                style={{
+                  fontSize: 14,
+                  fontFamily: "Inter_600SemiBold",
+                  color: c.text,
+                }}
+              >
                 {t.common.cancel}
               </Text>
             </Pressable>
@@ -56,10 +92,7 @@ export function ConfirmDialog({
               onPress={onConfirm}
               style={({ pressed }) => [
                 styles.confirmBtn,
-                {
-                  backgroundColor:
-                    variant === "danger" ? c.danger : c.primary,
-                },
+                { backgroundColor: accent },
                 pressed && { opacity: 0.85 },
               ]}
             >
@@ -79,42 +112,49 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    paddingHorizontal: 24,
+    paddingHorizontal: spacing["2xl"],
   },
   backdrop: {
     ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0,0,0,0.3)",
+    backgroundColor: "rgba(0,0,0,0.4)",
   },
   dialog: {
     width: "100%",
     maxWidth: 360,
-    borderRadius: radius.lg,
-    padding: 24,
+    borderRadius: radius.xl,
+    padding: spacing["2xl"],
+    alignItems: "center",
   },
-  desc: {
-    marginTop: 8,
+  iconWrap: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: "center",
+    justifyContent: "center",
   },
   actions: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 20,
+    gap: spacing.md,
+    marginTop: spacing.xl,
+    width: "100%",
   },
   cancelBtn: {
     flex: 1,
     borderWidth: 1,
     borderRadius: radius.md,
-    paddingVertical: 10,
+    paddingVertical: 12,
     alignItems: "center",
   },
   confirmBtn: {
     flex: 1,
     borderRadius: radius.md,
-    paddingVertical: 10,
+    paddingVertical: 12,
     alignItems: "center",
   },
   confirmText: {
     fontSize: 14,
-    fontWeight: "700",
+    fontFamily: "Inter_700Bold",
     color: "#FFFFFF",
+    letterSpacing: 0.2,
   },
 });

--- a/packages/psychologist-mobapp/components/diagnostics/DiagnosticsFiltersSheet.tsx
+++ b/packages/psychologist-mobapp/components/diagnostics/DiagnosticsFiltersSheet.tsx
@@ -11,8 +11,9 @@ import { Ionicons } from "@expo/vector-icons";
 import { testDefinitions, type Severity } from "@tirek/shared";
 import { Text, Button } from "../ui";
 import { useT, useLanguage } from "../../lib/hooks/useLanguage";
-import { useThemeColors, radius } from "../../lib/theme";
+import { useThemeColors, radius, spacing } from "../../lib/theme";
 import { hapticLight } from "../../lib/haptics";
+import { colors as ds } from "@tirek/shared/design-system";
 import type { DiagnosticsFilters } from "../../lib/api/diagnostics";
 
 interface Props {
@@ -86,21 +87,39 @@ export function DiagnosticsFiltersSheet({
       <View style={styles.wrapper}>
         <Pressable style={styles.backdrop} onPress={onClose} />
         <View style={[styles.content, { backgroundColor: c.surface }]}>
-          <View style={styles.dragHandle}>
-            <View style={[styles.dragBar, { backgroundColor: c.border }]} />
+          <View style={styles.handleWrap}>
+            <View style={[styles.handle, { backgroundColor: c.borderLight }]} />
           </View>
+
           <View style={styles.header}>
-            <Text variant="h3" style={{ fontWeight: "700" }}>
+            <Text
+              style={{
+                fontSize: 18,
+                lineHeight: 24,
+                fontFamily: "Inter_700Bold",
+                color: c.text,
+                flex: 1,
+              }}
+            >
               {t.psychologist.filtersTitle}
             </Text>
             <Pressable
               onPress={onClose}
-              style={[styles.closeBtn, { backgroundColor: c.surfaceSecondary }]}
+              style={({ pressed }) => [
+                styles.closeBtn,
+                { backgroundColor: c.surfaceSecondary },
+                pressed && { opacity: 0.7 },
+              ]}
             >
-              <Ionicons name="close" size={16} color={c.textLight} />
+              <Ionicons name="close" size={18} color={c.textLight} />
             </Pressable>
           </View>
-          <ScrollView contentContainerStyle={styles.body}>
+
+          <ScrollView
+            style={styles.body}
+            contentContainerStyle={styles.bodyContent}
+            showsVerticalScrollIndicator={false}
+          >
             <Section
               title={t.psychologist.filtersTest}
               c={c}
@@ -133,7 +152,7 @@ export function DiagnosticsFiltersSheet({
             />
             <View style={styles.dateRow}>
               <View style={{ flex: 1 }}>
-                <Text variant="caption" style={styles.label}>
+                <Text style={[styles.label, { color: c.textLight }]}>
                   {t.psychologist.filtersDateFrom}
                 </Text>
                 <TextInput
@@ -144,12 +163,16 @@ export function DiagnosticsFiltersSheet({
                   maxLength={10}
                   style={[
                     styles.input,
-                    { borderColor: c.borderLight, color: c.text },
+                    {
+                      borderColor: c.borderLight,
+                      color: c.text,
+                      backgroundColor: c.bg,
+                    },
                   ]}
                 />
               </View>
               <View style={{ flex: 1 }}>
-                <Text variant="caption" style={styles.label}>
+                <Text style={[styles.label, { color: c.textLight }]}>
                   {t.psychologist.filtersDateTo}
                 </Text>
                 <TextInput
@@ -160,30 +183,33 @@ export function DiagnosticsFiltersSheet({
                   maxLength={10}
                   style={[
                     styles.input,
-                    { borderColor: c.borderLight, color: c.text },
+                    {
+                      borderColor: c.borderLight,
+                      color: c.text,
+                      backgroundColor: c.bg,
+                    },
                   ]}
                 />
               </View>
             </View>
-            <View style={styles.actions}>
-              <View style={{ flex: 1 }}>
-                <Button
-                  title={t.psychologist.filtersReset}
-                  variant="secondary"
-                  size="md"
-                  onPress={reset}
-                />
-              </View>
-              <View style={{ flex: 2 }}>
-                <Button
-                  title={t.psychologist.filtersApply}
-                  variant="primary"
-                  size="md"
-                  onPress={apply}
-                />
-              </View>
-            </View>
           </ScrollView>
+
+          <View style={[styles.footer, { borderTopColor: c.borderLight }]}>
+            <Button
+              title={t.psychologist.filtersReset}
+              variant="secondary"
+              size="md"
+              onPress={reset}
+              style={{ flex: 1 }}
+            />
+            <Button
+              title={t.psychologist.filtersApply}
+              variant="primary"
+              size="md"
+              onPress={apply}
+              style={{ flex: 2 }}
+            />
+          </View>
         </View>
       </View>
     </Modal>
@@ -202,63 +228,69 @@ interface SectionProps {
 function Section({ title, c, t, value, setValue, options }: SectionProps) {
   return (
     <View style={styles.section}>
-      <Text variant="caption" style={styles.label}>
-        {title}
-      </Text>
+      <Text style={[styles.label, { color: c.textLight }]}>{title}</Text>
       <View style={styles.chips}>
-        <Pressable
+        <Chip
+          label={t.psychologist.codeAny}
+          active={value === ""}
           onPress={() => {
             hapticLight();
             setValue("");
           }}
-          style={[
-            styles.chip,
-            value === ""
-              ? { backgroundColor: c.primary }
-              : { backgroundColor: c.surfaceSecondary },
-          ]}
-        >
-          <Text
-            variant="small"
-            style={{
-              fontWeight: "600",
-              color: value === "" ? "#FFF" : c.textLight,
-            }}
-          >
-            {t.psychologist.codeAny}
-          </Text>
-        </Pressable>
+          c={c}
+        />
         {options.map((opt) => {
           const active = value === opt.value;
           return (
-            <Pressable
+            <Chip
               key={opt.value}
+              label={opt.label}
+              active={active}
               onPress={() => {
                 hapticLight();
                 setValue(active ? "" : opt.value);
               }}
-              style={[
-                styles.chip,
-                active
-                  ? { backgroundColor: c.primary }
-                  : { backgroundColor: c.surfaceSecondary },
-              ]}
-            >
-              <Text
-                variant="small"
-                style={{
-                  fontWeight: "600",
-                  color: active ? "#FFF" : c.textLight,
-                }}
-                numberOfLines={1}
-              >
-                {opt.label}
-              </Text>
-            </Pressable>
+              c={c}
+            />
           );
         })}
       </View>
     </View>
+  );
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+  c,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  c: ReturnType<typeof useThemeColors>;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.chip,
+        active
+          ? { backgroundColor: ds.brandSoft, borderColor: `${c.primary}33` }
+          : { backgroundColor: c.surfaceSecondary, borderColor: c.borderLight },
+      ]}
+    >
+      <Text
+        style={{
+          fontSize: 12,
+          fontFamily: "Inter_600SemiBold",
+          color: active ? c.primaryDark : c.textLight,
+        }}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -269,26 +301,27 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0,0,0,0.4)",
   },
   content: {
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
+    borderTopLeftRadius: radius["3xl"],
+    borderTopRightRadius: radius["3xl"],
     maxHeight: "85%",
   },
-  dragHandle: {
+  handleWrap: {
     alignItems: "center",
-    paddingTop: 12,
+    paddingTop: 10,
     paddingBottom: 4,
   },
-  dragBar: {
+  handle: {
     width: 40,
     height: 4,
     borderRadius: 2,
   },
   header: {
     flexDirection: "row",
-    justifyContent: "space-between",
     alignItems: "center",
-    paddingHorizontal: 20,
-    paddingBottom: 12,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
   },
   closeBtn: {
     width: 32,
@@ -298,42 +331,52 @@ const styles = StyleSheet.create({
     justifyContent: "center",
   },
   body: {
-    paddingHorizontal: 20,
-    paddingBottom: 32,
-    gap: 16,
+    paddingHorizontal: spacing.xl,
+  },
+  bodyContent: {
+    paddingBottom: spacing.lg,
+    gap: spacing.lg,
   },
   section: {
-    gap: 6,
+    gap: spacing.sm,
   },
   label: {
-    fontWeight: "600",
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
     marginBottom: 4,
   },
   chips: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 6,
+    gap: spacing.sm,
   },
   chip: {
-    paddingHorizontal: 12,
+    paddingHorizontal: spacing.md,
     paddingVertical: 6,
     borderRadius: 999,
+    borderWidth: 1,
   },
   dateRow: {
     flexDirection: "row",
-    gap: 8,
+    gap: spacing.sm,
   },
   input: {
     height: 40,
     borderWidth: 1,
-    borderRadius: radius.sm,
+    borderRadius: radius.md,
     paddingHorizontal: 10,
     fontFamily: "Inter_400Regular",
     fontSize: 13,
   },
-  actions: {
+  footer: {
     flexDirection: "row",
-    gap: 8,
-    marginTop: 8,
+    gap: spacing.md,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    borderTopWidth: 1,
   },
 });

--- a/packages/psychologist-mobapp/components/office-hours/IntervalsEditorSheet.tsx
+++ b/packages/psychologist-mobapp/components/office-hours/IntervalsEditorSheet.tsx
@@ -95,85 +95,188 @@ export function IntervalsEditorSheet({
           </View>
 
           <View style={styles.headerRow}>
-            <Text variant="h3">{title}</Text>
-            <Pressable onPress={onClose} hitSlop={8}>
-              <Ionicons name="close" size={22} color={c.textLight} />
+            <Text
+              style={{
+                fontSize: 18,
+                lineHeight: 24,
+                fontFamily: "Inter_700Bold",
+                color: c.text,
+                flex: 1,
+              }}
+            >
+              {title}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              style={({ pressed }) => [
+                styles.closeBtn,
+                { backgroundColor: c.surfaceSecondary },
+                pressed && { opacity: 0.7 },
+              ]}
+            >
+              <Ionicons name="close" size={18} color={c.textLight} />
             </Pressable>
           </View>
 
-          {showDayOffToggle ? (
-            <View style={styles.dayOffRow}>
-              <Text>Выходной</Text>
-              <Switch
-                value={dayOff}
-                onValueChange={(v) => {
-                  hapticLight();
-                  setDayOff(v);
-                  setError(null);
-                }}
-              />
-            </View>
-          ) : null}
+          <ScrollView
+            style={styles.body}
+            contentContainerStyle={styles.bodyContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {showDayOffToggle ? (
+              <View
+                style={[
+                  styles.dayOffRow,
+                  {
+                    backgroundColor: c.surfaceSecondary,
+                    borderColor: c.borderLight,
+                  },
+                ]}
+              >
+                <Text
+                  style={{
+                    fontSize: 14,
+                    fontFamily: "Inter_600SemiBold",
+                    color: c.text,
+                    flex: 1,
+                  }}
+                >
+                  Выходной
+                </Text>
+                <Switch
+                  value={dayOff}
+                  onValueChange={(v) => {
+                    hapticLight();
+                    setDayOff(v);
+                    setError(null);
+                  }}
+                />
+              </View>
+            ) : null}
 
-          {!dayOff ? (
-            <ScrollView
-              style={{ maxHeight: 280 }}
-              contentContainerStyle={{ gap: spacing.sm }}
-            >
-              {intervals.map((iv, idx) => (
-                <View key={idx} style={styles.intervalRow}>
-                  <TextInput
-                    value={iv.start}
-                    onChangeText={(v) => updateInterval(idx, "start", v)}
-                    placeholder="09:00"
-                    placeholderTextColor={c.textLight}
-                    style={[styles.input, { borderColor: c.border, color: c.text }]}
-                    maxLength={5}
-                  />
-                  <Text style={{ color: c.textLight }}>—</Text>
-                  <TextInput
-                    value={iv.end}
-                    onChangeText={(v) => updateInterval(idx, "end", v)}
-                    placeholder="17:00"
-                    placeholderTextColor={c.textLight}
-                    style={[styles.input, { borderColor: c.border, color: c.text }]}
-                    maxLength={5}
-                  />
+            {!dayOff ? (
+              <>
+                <Text style={[styles.label, { color: c.textLight }]}>
+                  Интервалы
+                </Text>
+                <View style={{ gap: spacing.sm }}>
+                  {intervals.map((iv, idx) => (
+                    <View key={idx} style={styles.intervalRow}>
+                      <TextInput
+                        value={iv.start}
+                        onChangeText={(v) => updateInterval(idx, "start", v)}
+                        placeholder="09:00"
+                        placeholderTextColor={c.textLight}
+                        style={[
+                          styles.input,
+                          {
+                            borderColor: c.borderLight,
+                            color: c.text,
+                            backgroundColor: c.bg,
+                          },
+                        ]}
+                        maxLength={5}
+                      />
+                      <Text style={{ color: c.textLight }}>—</Text>
+                      <TextInput
+                        value={iv.end}
+                        onChangeText={(v) => updateInterval(idx, "end", v)}
+                        placeholder="17:00"
+                        placeholderTextColor={c.textLight}
+                        style={[
+                          styles.input,
+                          {
+                            borderColor: c.borderLight,
+                            color: c.text,
+                            backgroundColor: c.bg,
+                          },
+                        ]}
+                        maxLength={5}
+                      />
+                      <Pressable
+                        onPress={() => removeInterval(idx)}
+                        hitSlop={8}
+                        style={({ pressed }) => [
+                          styles.iconBtn,
+                          pressed && { opacity: 0.6 },
+                        ]}
+                      >
+                        <Ionicons
+                          name="trash-outline"
+                          size={18}
+                          color={c.textLight}
+                        />
+                      </Pressable>
+                    </View>
+                  ))}
                   <Pressable
-                    onPress={() => removeInterval(idx)}
-                    hitSlop={8}
-                    style={({ pressed }) => [pressed && { opacity: 0.6 }]}
+                    onPress={addInterval}
+                    style={({ pressed }) => [
+                      styles.addRow,
+                      { borderColor: `${c.primary}33` },
+                      pressed && { opacity: 0.85 },
+                    ]}
                   >
-                    <Ionicons name="trash-outline" size={20} color={c.textLight} />
+                    <Ionicons
+                      name="add-circle-outline"
+                      size={18}
+                      color={c.primary}
+                    />
+                    <Text
+                      style={{
+                        color: c.primary,
+                        fontFamily: "Inter_600SemiBold",
+                        fontSize: 13,
+                      }}
+                    >
+                      Добавить интервал
+                    </Text>
                   </Pressable>
                 </View>
-              ))}
-              <Pressable onPress={addInterval} style={styles.addRow}>
-                <Ionicons name="add-circle-outline" size={20} color={c.primary} />
-                <Text style={{ color: c.primary }}>Добавить интервал</Text>
-              </Pressable>
-            </ScrollView>
-          ) : null}
+              </>
+            ) : null}
 
-          <Text variant="caption" style={styles.notesLabel}>
-            Заметка (необязательно)
-          </Text>
-          <TextInput
-            value={notes}
-            onChangeText={setNotes}
-            placeholder="напр. конференция"
-            placeholderTextColor={c.textLight}
-            style={[
-              styles.notesInput,
-              { borderColor: c.border, color: c.text, backgroundColor: c.surfaceSecondary },
-            ]}
-          />
+            <Text style={[styles.label, { color: c.textLight, marginTop: spacing.lg }]}>
+              Заметка (необязательно)
+            </Text>
+            <TextInput
+              value={notes}
+              onChangeText={setNotes}
+              placeholder="напр. конференция"
+              placeholderTextColor={c.textLight}
+              style={[
+                styles.notesInput,
+                {
+                  borderColor: c.borderLight,
+                  color: c.text,
+                  backgroundColor: c.bg,
+                },
+              ]}
+            />
 
-          {error ? (
-            <Text style={[styles.error, { color: c.danger }]}>{error}</Text>
-          ) : null}
+            {error ? (
+              <View
+                style={[
+                  styles.errorBox,
+                  {
+                    backgroundColor: `${c.danger}14`,
+                    borderColor: `${c.danger}33`,
+                  },
+                ]}
+              >
+                <Ionicons
+                  name="alert-circle-outline"
+                  size={14}
+                  color={c.danger}
+                />
+                <Text style={{ fontSize: 13, color: c.danger, flex: 1 }}>
+                  {error}
+                </Text>
+              </View>
+            ) : null}
+          </ScrollView>
 
-          <View style={styles.actions}>
+          <View style={[styles.footer, { borderTopColor: c.borderLight }]}>
             <Button
               title="Отмена"
               variant="secondary"
@@ -201,26 +304,58 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0,0,0,0.4)",
   },
   sheet: {
-    borderTopLeftRadius: radius.xl,
-    borderTopRightRadius: radius.xl,
-    paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 24,
+    borderTopLeftRadius: radius["3xl"],
+    borderTopRightRadius: radius["3xl"],
+    maxHeight: "85%",
   },
-  handleWrap: { alignItems: "center", paddingVertical: 8 },
-  handle: { width: 40, height: 4, borderRadius: 2 },
+  handleWrap: {
+    alignItems: "center",
+    paddingTop: 10,
+    paddingBottom: 4,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+  },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 12,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    paddingHorizontal: spacing.xl,
+  },
+  bodyContent: {
+    paddingBottom: spacing.lg,
   },
   dayOffRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 8,
-    marginBottom: 8,
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    marginBottom: spacing.lg,
+  },
+  label: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginBottom: spacing.sm,
   },
   intervalRow: {
     flexDirection: "row",
@@ -234,29 +369,49 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingVertical: 8,
     fontSize: 15,
+    fontFamily: "Inter_500Medium",
     fontVariant: ["tabular-nums"],
+  },
+  iconBtn: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
   },
   addRow: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
     gap: 6,
-    paddingVertical: 6,
+    paddingVertical: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderStyle: "dashed",
   },
-  notesLabel: { marginTop: 16, marginBottom: 6 },
   notesInput: {
     borderWidth: 1,
     borderRadius: radius.md,
     paddingHorizontal: 10,
-    paddingVertical: 8,
+    paddingVertical: 10,
     fontSize: 14,
+    fontFamily: "Inter_400Regular",
+    minHeight: 44,
   },
-  error: {
-    marginTop: 12,
-    fontSize: 13,
-  },
-  actions: {
+  errorBox: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 20,
+    alignItems: "center",
+    gap: 8,
+    padding: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    marginTop: spacing.md,
+  },
+  footer: {
+    flexDirection: "row",
+    gap: spacing.md,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    borderTopWidth: 1,
   },
 });

--- a/packages/psychologist-mobapp/components/office-hours/OverrideEditorSheet.tsx
+++ b/packages/psychologist-mobapp/components/office-hours/OverrideEditorSheet.tsx
@@ -13,13 +13,14 @@ import { Text, Button } from "../ui";
 import { useThemeColors, radius, spacing } from "../../lib/theme";
 import { hapticLight } from "../../lib/haptics";
 import { validateIntervals } from "@tirek/shared/office-hours";
+import { colors as ds } from "@tirek/shared/design-system";
 import type { OfficeHoursInterval } from "@tirek/shared";
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 function todayIso(): string {
   const d = new Date();
-  const offset = 5 * 60 * 60 * 1000; // Almaty UTC+5
+  const offset = 5 * 60 * 60 * 1000;
   const a = new Date(d.getTime() + offset);
   return `${a.getUTCFullYear()}-${String(a.getUTCMonth() + 1).padStart(2, "0")}-${String(a.getUTCDate()).padStart(2, "0")}`;
 }
@@ -32,7 +33,6 @@ function addDaysIso(iso: string, days: number): string {
 
 export interface OverrideEditorSheetProps {
   open: boolean;
-  /** Если задан — режим редактирования: дата фиксирована, нельзя менять. */
   fixedDate?: string;
   initialIntervals: OfficeHoursInterval[];
   initialNotes: string | null;
@@ -103,153 +103,286 @@ export function OverrideEditorSheet({
           </View>
 
           <View style={styles.headerRow}>
-            <Text variant="h3">{fixedDate ? "Исключение" : "Новое исключение"}</Text>
-            <Pressable onPress={onClose} hitSlop={8}>
-              <Ionicons name="close" size={22} color={c.textLight} />
+            <Text
+              style={{
+                fontSize: 18,
+                lineHeight: 24,
+                fontFamily: "Inter_700Bold",
+                color: c.text,
+                flex: 1,
+              }}
+            >
+              {fixedDate ? "Исключение" : "Новое исключение"}
+            </Text>
+            <Pressable
+              onPress={onClose}
+              style={({ pressed }) => [
+                styles.closeBtn,
+                { backgroundColor: c.surfaceSecondary },
+                pressed && { opacity: 0.7 },
+              ]}
+            >
+              <Ionicons name="close" size={18} color={c.textLight} />
             </Pressable>
           </View>
 
-          <Text variant="caption" style={styles.label}>
-            Дата
-          </Text>
-          {fixedDate ? (
-            <Text style={{ color: c.text, marginBottom: 8 }}>{fixedDate}</Text>
-          ) : (
-            <>
-              <TextInput
-                value={date}
-                onChangeText={(v) => {
-                  setDate(v);
+          <ScrollView
+            style={styles.body}
+            contentContainerStyle={styles.bodyContent}
+            showsVerticalScrollIndicator={false}
+          >
+            <Text style={[styles.label, { color: c.textLight }]}>Дата</Text>
+            {fixedDate ? (
+              <Text
+                style={{
+                  fontSize: 16,
+                  fontFamily: "Inter_600SemiBold",
+                  color: c.text,
+                  marginBottom: spacing.lg,
+                }}
+              >
+                {fixedDate}
+              </Text>
+            ) : (
+              <>
+                <TextInput
+                  value={date}
+                  onChangeText={(v) => {
+                    setDate(v);
+                    setError(null);
+                  }}
+                  placeholder="2026-04-30"
+                  placeholderTextColor={c.textLight}
+                  style={[
+                    styles.input,
+                    {
+                      borderColor: c.borderLight,
+                      color: c.text,
+                      backgroundColor: c.bg,
+                    },
+                  ]}
+                  maxLength={10}
+                />
+                <View style={styles.quickRow}>
+                  {(
+                    [
+                      { label: "Сегодня", days: 0 },
+                      { label: "Завтра", days: 1 },
+                      { label: "+7 дней", days: 7 },
+                    ] as const
+                  ).map(({ label, days }) => {
+                    const target = addDaysIso(todayIso(), days);
+                    const active = date === target;
+                    return (
+                      <Pressable
+                        key={label}
+                        onPress={() => {
+                          hapticLight();
+                          setDate(target);
+                          setError(null);
+                        }}
+                        style={[
+                          styles.quickChip,
+                          active
+                            ? {
+                                backgroundColor: ds.brandSoft,
+                                borderColor: `${c.primary}33`,
+                              }
+                            : {
+                                backgroundColor: c.surfaceSecondary,
+                                borderColor: c.borderLight,
+                              },
+                        ]}
+                      >
+                        <Text
+                          style={{
+                            fontSize: 12,
+                            fontFamily: "Inter_600SemiBold",
+                            color: active ? c.primaryDark : c.textLight,
+                          }}
+                        >
+                          {label}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </>
+            )}
+
+            <View
+              style={[
+                styles.dayOffRow,
+                {
+                  backgroundColor: c.surfaceSecondary,
+                  borderColor: c.borderLight,
+                },
+              ]}
+            >
+              <Text
+                style={{
+                  fontSize: 14,
+                  fontFamily: "Inter_600SemiBold",
+                  color: c.text,
+                  flex: 1,
+                }}
+              >
+                Выходной
+              </Text>
+              <Switch
+                value={dayOff}
+                onValueChange={(v) => {
+                  hapticLight();
+                  setDayOff(v);
                   setError(null);
                 }}
-                placeholder="2026-04-30"
-                placeholderTextColor={c.textLight}
-                style={[
-                  styles.input,
-                  { borderColor: c.border, color: c.text, backgroundColor: c.surfaceSecondary },
-                ]}
-                maxLength={10}
               />
-              <View style={styles.quickRow}>
-                <Pressable
-                  onPress={() => {
-                    hapticLight();
-                    setDate(todayIso());
-                    setError(null);
-                  }}
-                  style={[styles.quickChip, { backgroundColor: c.surfaceSecondary }]}
-                >
-                  <Text variant="small" style={{ color: c.textLight }}>
-                    Сегодня
-                  </Text>
-                </Pressable>
-                <Pressable
-                  onPress={() => {
-                    hapticLight();
-                    setDate(addDaysIso(todayIso(), 1));
-                    setError(null);
-                  }}
-                  style={[styles.quickChip, { backgroundColor: c.surfaceSecondary }]}
-                >
-                  <Text variant="small" style={{ color: c.textLight }}>
-                    Завтра
-                  </Text>
-                </Pressable>
-                <Pressable
-                  onPress={() => {
-                    hapticLight();
-                    setDate(addDaysIso(todayIso(), 7));
-                    setError(null);
-                  }}
-                  style={[styles.quickChip, { backgroundColor: c.surfaceSecondary }]}
-                >
-                  <Text variant="small" style={{ color: c.textLight }}>
-                    +7 дней
-                  </Text>
-                </Pressable>
-              </View>
-            </>
-          )}
+            </View>
 
-          <View style={styles.dayOffRow}>
-            <Text>Выходной</Text>
-            <Switch
-              value={dayOff}
-              onValueChange={(v) => {
-                hapticLight();
-                setDayOff(v);
-                setError(null);
-              }}
-            />
-          </View>
-
-          {!dayOff ? (
-            <ScrollView
-              style={{ maxHeight: 220 }}
-              contentContainerStyle={{ gap: spacing.sm }}
-            >
-              {intervals.map((iv, idx) => (
-                <View key={idx} style={styles.intervalRow}>
-                  <TextInput
-                    value={iv.start}
-                    onChangeText={(v) => updateInterval(idx, "start", v)}
-                    placeholder="09:00"
-                    placeholderTextColor={c.textLight}
-                    style={[styles.input, { borderColor: c.border, color: c.text, flex: 1 }]}
-                    maxLength={5}
-                  />
-                  <Text style={{ color: c.textLight }}>—</Text>
-                  <TextInput
-                    value={iv.end}
-                    onChangeText={(v) => updateInterval(idx, "end", v)}
-                    placeholder="17:00"
-                    placeholderTextColor={c.textLight}
-                    style={[styles.input, { borderColor: c.border, color: c.text, flex: 1 }]}
-                    maxLength={5}
-                  />
+            {!dayOff ? (
+              <>
+                <Text
+                  style={[
+                    styles.label,
+                    { color: c.textLight, marginTop: spacing.lg },
+                  ]}
+                >
+                  Интервалы
+                </Text>
+                <View style={{ gap: spacing.sm }}>
+                  {intervals.map((iv, idx) => (
+                    <View key={idx} style={styles.intervalRow}>
+                      <TextInput
+                        value={iv.start}
+                        onChangeText={(v) => updateInterval(idx, "start", v)}
+                        placeholder="09:00"
+                        placeholderTextColor={c.textLight}
+                        style={[
+                          styles.input,
+                          {
+                            borderColor: c.borderLight,
+                            color: c.text,
+                            backgroundColor: c.bg,
+                            flex: 1,
+                          },
+                        ]}
+                        maxLength={5}
+                      />
+                      <Text style={{ color: c.textLight }}>—</Text>
+                      <TextInput
+                        value={iv.end}
+                        onChangeText={(v) => updateInterval(idx, "end", v)}
+                        placeholder="17:00"
+                        placeholderTextColor={c.textLight}
+                        style={[
+                          styles.input,
+                          {
+                            borderColor: c.borderLight,
+                            color: c.text,
+                            backgroundColor: c.bg,
+                            flex: 1,
+                          },
+                        ]}
+                        maxLength={5}
+                      />
+                      <Pressable
+                        onPress={() => {
+                          hapticLight();
+                          setIntervals((arr) => arr.filter((_, i) => i !== idx));
+                        }}
+                        hitSlop={8}
+                        style={({ pressed }) => [
+                          styles.iconBtn,
+                          pressed && { opacity: 0.6 },
+                        ]}
+                      >
+                        <Ionicons
+                          name="trash-outline"
+                          size={18}
+                          color={c.textLight}
+                        />
+                      </Pressable>
+                    </View>
+                  ))}
                   <Pressable
                     onPress={() => {
                       hapticLight();
-                      setIntervals((arr) => arr.filter((_, i) => i !== idx));
+                      setIntervals((arr) => [
+                        ...arr,
+                        { start: "09:00", end: "12:00" },
+                      ]);
                     }}
-                    hitSlop={8}
+                    style={({ pressed }) => [
+                      styles.addRow,
+                      { borderColor: `${c.primary}33` },
+                      pressed && { opacity: 0.85 },
+                    ]}
                   >
-                    <Ionicons name="trash-outline" size={20} color={c.textLight} />
+                    <Ionicons
+                      name="add-circle-outline"
+                      size={18}
+                      color={c.primary}
+                    />
+                    <Text
+                      style={{
+                        color: c.primary,
+                        fontFamily: "Inter_600SemiBold",
+                        fontSize: 13,
+                      }}
+                    >
+                      Добавить интервал
+                    </Text>
                   </Pressable>
                 </View>
-              ))}
-              <Pressable
-                onPress={() => {
-                  hapticLight();
-                  setIntervals((arr) => [...arr, { start: "09:00", end: "12:00" }]);
-                }}
-                style={styles.addRow}
+              </>
+            ) : null}
+
+            <Text
+              style={[
+                styles.label,
+                { color: c.textLight, marginTop: spacing.lg },
+              ]}
+            >
+              Заметка (необязательно)
+            </Text>
+            <TextInput
+              value={notes}
+              onChangeText={setNotes}
+              placeholder="напр. конференция"
+              placeholderTextColor={c.textLight}
+              style={[
+                styles.notesInput,
+                {
+                  borderColor: c.borderLight,
+                  color: c.text,
+                  backgroundColor: c.bg,
+                },
+              ]}
+            />
+
+            {error ? (
+              <View
+                style={[
+                  styles.errorBox,
+                  {
+                    backgroundColor: `${c.danger}14`,
+                    borderColor: `${c.danger}33`,
+                  },
+                ]}
               >
-                <Ionicons name="add-circle-outline" size={20} color={c.primary} />
-                <Text style={{ color: c.primary }}>Добавить интервал</Text>
-              </Pressable>
-            </ScrollView>
-          ) : null}
+                <Ionicons
+                  name="alert-circle-outline"
+                  size={14}
+                  color={c.danger}
+                />
+                <Text style={{ fontSize: 13, color: c.danger, flex: 1 }}>
+                  {error}
+                </Text>
+              </View>
+            ) : null}
+          </ScrollView>
 
-          <Text variant="caption" style={styles.label}>
-            Заметка (необязательно)
-          </Text>
-          <TextInput
-            value={notes}
-            onChangeText={setNotes}
-            placeholder="напр. конференция"
-            placeholderTextColor={c.textLight}
-            style={[
-              styles.input,
-              { borderColor: c.border, color: c.text, backgroundColor: c.surfaceSecondary },
-            ]}
-          />
-
-          {error ? (
-            <Text style={[styles.error, { color: c.danger }]}>{error}</Text>
-          ) : null}
-
-          <View style={styles.actions}>
+          <View style={[styles.footer, { borderTopColor: c.borderLight }]}>
             <Button
               title="Отмена"
               variant="secondary"
@@ -277,60 +410,124 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0,0,0,0.4)",
   },
   sheet: {
-    borderTopLeftRadius: radius.xl,
-    borderTopRightRadius: radius.xl,
-    paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 24,
+    borderTopLeftRadius: radius["3xl"],
+    borderTopRightRadius: radius["3xl"],
+    maxHeight: "90%",
   },
-  handleWrap: { alignItems: "center", paddingVertical: 8 },
-  handle: { width: 40, height: 4, borderRadius: 2 },
+  handleWrap: {
+    alignItems: "center",
+    paddingTop: 10,
+    paddingBottom: 4,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+  },
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 12,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
   },
-  label: { marginTop: 12, marginBottom: 6 },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    paddingHorizontal: spacing.xl,
+  },
+  bodyContent: {
+    paddingBottom: spacing.lg,
+  },
+  label: {
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginBottom: spacing.sm,
+  },
   input: {
     borderWidth: 1,
     borderRadius: radius.md,
     paddingHorizontal: 10,
     paddingVertical: 8,
     fontSize: 15,
+    fontFamily: "Inter_500Medium",
     fontVariant: ["tabular-nums"],
   },
   quickRow: {
     flexDirection: "row",
-    gap: 6,
-    marginTop: 8,
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+    marginBottom: spacing.lg,
   },
   quickChip: {
-    paddingHorizontal: 10,
+    paddingHorizontal: spacing.md,
     paddingVertical: 6,
     borderRadius: 999,
+    borderWidth: 1,
   },
   dayOffRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: 12,
+    gap: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
   },
   intervalRow: {
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
   },
+  iconBtn: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
   addRow: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
     gap: 6,
-    paddingVertical: 6,
+    paddingVertical: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderStyle: "dashed",
   },
-  error: { marginTop: 12, fontSize: 13 },
-  actions: {
+  notesInput: {
+    borderWidth: 1,
+    borderRadius: radius.md,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    fontSize: 14,
+    fontFamily: "Inter_400Regular",
+    minHeight: 44,
+  },
+  errorBox: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 20,
+    alignItems: "center",
+    gap: 8,
+    padding: 10,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    marginTop: spacing.md,
+  },
+  footer: {
+    flexDirection: "row",
+    gap: spacing.md,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    borderTopWidth: 1,
   },
 });

--- a/packages/psychologist-mobapp/components/student/FiltersSheet.tsx
+++ b/packages/psychologist-mobapp/components/student/FiltersSheet.tsx
@@ -9,8 +9,9 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 import { useT } from "../../lib/hooks/useLanguage";
 import { Text, Button } from "../ui";
-import { useThemeColors, radius } from "../../lib/theme";
+import { useThemeColors, radius, spacing } from "../../lib/theme";
 import { hapticLight } from "../../lib/haptics";
+import { colors as ds } from "@tirek/shared/design-system";
 
 const GRADES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 const CLASS_LETTERS = ["А", "Ә", "Б", "В", "Г", "Д", "Е", "Ж", "З"];
@@ -68,131 +69,103 @@ export function FiltersSheet({
           </View>
 
           <View style={styles.headerRow}>
-            <Text variant="h3">{t.common.filters}</Text>
+            <Text
+              style={{
+                fontSize: 18,
+                lineHeight: 24,
+                fontFamily: "Inter_700Bold",
+                color: c.text,
+                flex: 1,
+              }}
+            >
+              {t.common.filters}
+            </Text>
             <Pressable
               onPress={onClose}
-              hitSlop={8}
-              style={({ pressed }) => [pressed && { opacity: 0.6 }]}
+              style={({ pressed }) => [
+                styles.closeBtn,
+                { backgroundColor: c.surfaceSecondary },
+                pressed && { opacity: 0.7 },
+              ]}
             >
-              <Ionicons name="close" size={22} color={c.textLight} />
+              <Ionicons name="close" size={18} color={c.textLight} />
             </Pressable>
           </View>
 
-          <Text variant="caption" style={styles.sectionLabel}>
-            {t.psychologist.studentClass}
-          </Text>
           <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.chipsRow}
+            style={styles.body}
+            contentContainerStyle={styles.bodyContent}
+            showsVerticalScrollIndicator={false}
           >
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                setDraftGrade(null);
-              }}
-              style={[
-                styles.chip,
-                draftGrade === null
-                  ? { backgroundColor: c.primary }
-                  : { backgroundColor: c.surfaceSecondary },
-              ]}
+            <Text style={[styles.sectionLabel, { color: c.textLight }]}>
+              {t.psychologist.studentClass}
+            </Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.chipsRow}
             >
-              <Text
-                variant="small"
-                style={{
-                  fontFamily: "DMSans-SemiBold",
-                  color: draftGrade === null ? "#FFF" : c.textLight,
-                }}
-              >
-                {t.psychologist.allGrades}
-              </Text>
-            </Pressable>
-            {GRADES.map((g) => (
-              <Pressable
-                key={g}
+              <Chip
+                label={t.psychologist.allGrades}
+                active={draftGrade === null}
                 onPress={() => {
                   hapticLight();
-                  setDraftGrade(draftGrade === g ? null : g);
+                  setDraftGrade(null);
                 }}
-                style={[
-                  styles.chip,
-                  draftGrade === g
-                    ? { backgroundColor: c.primary }
-                    : { backgroundColor: c.surfaceSecondary },
-                ]}
-              >
-                <Text
-                  variant="small"
-                  style={{
-                    fontFamily: "DMSans-SemiBold",
-                    color: draftGrade === g ? "#FFF" : c.textLight,
+                c={c}
+              />
+              {GRADES.map((g) => (
+                <Chip
+                  key={g}
+                  label={String(g)}
+                  active={draftGrade === g}
+                  onPress={() => {
+                    hapticLight();
+                    setDraftGrade(draftGrade === g ? null : g);
                   }}
-                >
-                  {g}
-                </Text>
-              </Pressable>
-            ))}
-          </ScrollView>
+                  c={c}
+                />
+              ))}
+            </ScrollView>
 
-          <Text variant="caption" style={styles.sectionLabel}>
-            {t.psychologist.classLetterLabel}
-          </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.chipsRow}
-          >
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                setDraftLetter(null);
-              }}
+            <Text
               style={[
-                styles.chip,
-                draftLetter === null
-                  ? { backgroundColor: c.primary }
-                  : { backgroundColor: c.surfaceSecondary },
+                styles.sectionLabel,
+                { color: c.textLight, marginTop: spacing.lg },
               ]}
             >
-              <Text
-                variant="small"
-                style={{
-                  fontFamily: "DMSans-SemiBold",
-                  color: draftLetter === null ? "#FFF" : c.textLight,
-                }}
-              >
-                {t.psychologist.allClasses}
-              </Text>
-            </Pressable>
-            {CLASS_LETTERS.map((l) => (
-              <Pressable
-                key={l}
+              {t.psychologist.classLetterLabel}
+            </Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.chipsRow}
+            >
+              <Chip
+                label={t.psychologist.allClasses}
+                active={draftLetter === null}
                 onPress={() => {
                   hapticLight();
-                  setDraftLetter(draftLetter === l ? null : l);
+                  setDraftLetter(null);
                 }}
-                style={[
-                  styles.chip,
-                  draftLetter === l
-                    ? { backgroundColor: c.primary }
-                    : { backgroundColor: c.surfaceSecondary },
-                ]}
-              >
-                <Text
-                  variant="small"
-                  style={{
-                    fontFamily: "DMSans-SemiBold",
-                    color: draftLetter === l ? "#FFF" : c.textLight,
+                c={c}
+              />
+              {CLASS_LETTERS.map((l) => (
+                <Chip
+                  key={l}
+                  label={l}
+                  active={draftLetter === l}
+                  onPress={() => {
+                    hapticLight();
+                    setDraftLetter(draftLetter === l ? null : l);
                   }}
-                >
-                  {l}
-                </Text>
-              </Pressable>
-            ))}
+                  c={c}
+                />
+              ))}
+            </ScrollView>
           </ScrollView>
 
-          <View style={styles.actions}>
+          <View style={[styles.footer, { borderTopColor: c.borderLight }]}>
             <Button
               title={t.common.reset}
               variant="secondary"
@@ -212,6 +185,40 @@ export function FiltersSheet({
   );
 }
 
+function Chip({
+  label,
+  active,
+  onPress,
+  c,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  c: ReturnType<typeof useThemeColors>;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.chip,
+        active
+          ? { backgroundColor: ds.brandSoft, borderColor: `${c.primary}33` }
+          : { backgroundColor: c.surfaceSecondary, borderColor: c.borderLight },
+      ]}
+    >
+      <Text
+        style={{
+          fontSize: 13,
+          fontFamily: "Inter_600SemiBold",
+          color: active ? c.primaryDark : c.textLight,
+        }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
 const styles = StyleSheet.create({
   root: {
     flex: 1,
@@ -222,15 +229,14 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0,0,0,0.4)",
   },
   sheet: {
-    borderTopLeftRadius: radius.xl,
-    borderTopRightRadius: radius.xl,
-    paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 24,
+    borderTopLeftRadius: radius["3xl"],
+    borderTopRightRadius: radius["3xl"],
+    maxHeight: "85%",
   },
   handleWrap: {
     alignItems: "center",
-    paddingVertical: 8,
+    paddingTop: 10,
+    paddingBottom: 4,
   },
   handle: {
     width: 40,
@@ -240,27 +246,50 @@ const styles = StyleSheet.create({
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 12,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    paddingHorizontal: spacing.xl,
+  },
+  bodyContent: {
+    paddingBottom: spacing.lg,
   },
   sectionLabel: {
-    marginTop: 12,
-    marginBottom: 8,
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginBottom: spacing.sm,
   },
   chipsRow: {
-    gap: 6,
+    gap: spacing.sm,
     flexDirection: "row",
     alignItems: "center",
-    paddingRight: 12,
+    paddingRight: spacing.md,
   },
   chip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 8,
     borderRadius: 999,
+    borderWidth: 1,
   },
-  actions: {
+  footer: {
     flexDirection: "row",
-    gap: 12,
-    marginTop: 20,
+    gap: spacing.md,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    borderTopWidth: 1,
   },
 });

--- a/packages/psychologist-mobapp/components/student/GenerateCodesSheet.tsx
+++ b/packages/psychologist-mobapp/components/student/GenerateCodesSheet.tsx
@@ -14,9 +14,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useT } from "../../lib/hooks/useLanguage";
 import { Text } from "../ui";
-import { useThemeColors, radius } from "../../lib/theme";
+import { useThemeColors, radius, spacing } from "../../lib/theme";
 import { hapticLight } from "../../lib/haptics";
 import { inviteCodesApi } from "../../lib/api/inviteCodes";
+import { colors as ds } from "@tirek/shared/design-system";
 
 const GRADES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
 const CLASS_LETTERS = ["А", "Ә", "Б", "В", "Г", "Д", "Е", "Ж", "З"];
@@ -107,28 +108,42 @@ export function GenerateCodesSheet({
             </View>
 
             <View style={styles.headerRow}>
-              <Text variant="h3">{t.psychologist.generateCodes}</Text>
+              <Text
+                style={{
+                  fontSize: 18,
+                  lineHeight: 24,
+                  fontFamily: "Inter_700Bold",
+                  color: c.text,
+                  flex: 1,
+                }}
+              >
+                {t.psychologist.generateCodes}
+              </Text>
               <Pressable
                 onPress={onClose}
-                hitSlop={8}
-                style={({ pressed }) => [pressed && { opacity: 0.6 }]}
+                style={({ pressed }) => [
+                  styles.closeBtn,
+                  { backgroundColor: c.surfaceSecondary },
+                  pressed && { opacity: 0.7 },
+                ]}
               >
-                <Ionicons name="close" size={22} color={c.textLight} />
+                <Ionicons name="close" size={18} color={c.textLight} />
               </Pressable>
             </View>
 
             <ScrollView
-              style={{ maxHeight: 480 }}
+              style={styles.body}
+              contentContainerStyle={styles.bodyContent}
               keyboardShouldPersistTaps="handled"
               showsVerticalScrollIndicator={false}
             >
-              <Text variant="caption" style={styles.sectionLabel}>
+              <Text style={[styles.sectionLabel, { color: c.textLight }]}>
                 {t.psychologist.studentNamesLabel}
               </Text>
               <View
                 style={[
                   styles.namesInput,
-                  { borderColor: c.borderLight, backgroundColor: c.surface },
+                  { borderColor: c.borderLight, backgroundColor: c.bg },
                 ]}
               >
                 <TextInput
@@ -143,13 +158,23 @@ export function GenerateCodesSheet({
                 />
               </View>
               <Text
-                variant="caption"
-                style={{ color: c.textLight, marginTop: 4 }}
+                style={{
+                  fontSize: 11,
+                  lineHeight: 14,
+                  color: c.textLight,
+                  marginTop: 4,
+                  fontFamily: "Inter_500Medium",
+                }}
               >
                 {studentNames.length} / 100
               </Text>
 
-              <Text variant="caption" style={styles.sectionLabel}>
+              <Text
+                style={[
+                  styles.sectionLabel,
+                  { color: c.textLight, marginTop: spacing.lg },
+                ]}
+              >
                 {t.auth.selectGrade}
               </Text>
               <ScrollView
@@ -158,58 +183,35 @@ export function GenerateCodesSheet({
                 contentContainerStyle={styles.chipsRow}
                 keyboardShouldPersistTaps="handled"
               >
-                <Pressable
+                <Chip
+                  label={t.psychologist.codeAny}
+                  active={grade === null}
                   onPress={() => {
                     hapticLight();
                     setGrade(null);
                   }}
-                  style={[
-                    styles.chip,
-                    {
-                      backgroundColor:
-                        grade === null ? c.primary : c.surfaceSecondary,
-                    },
-                  ]}
-                >
-                  <Text
-                    variant="small"
-                    style={{
-                      fontFamily: "DMSans-SemiBold",
-                      color: grade === null ? "#FFF" : c.textLight,
-                    }}
-                  >
-                    {t.psychologist.codeAny}
-                  </Text>
-                </Pressable>
+                  c={c}
+                />
                 {GRADES.map((g) => (
-                  <Pressable
+                  <Chip
                     key={g}
+                    label={String(g)}
+                    active={grade === g}
                     onPress={() => {
                       hapticLight();
                       setGrade(grade === g ? null : g);
                     }}
-                    style={[
-                      styles.chip,
-                      {
-                        backgroundColor:
-                          grade === g ? c.primary : c.surfaceSecondary,
-                      },
-                    ]}
-                  >
-                    <Text
-                      variant="small"
-                      style={{
-                        fontFamily: "DMSans-SemiBold",
-                        color: grade === g ? "#FFF" : c.textLight,
-                      }}
-                    >
-                      {g}
-                    </Text>
-                  </Pressable>
+                    c={c}
+                  />
                 ))}
               </ScrollView>
 
-              <Text variant="caption" style={styles.sectionLabel}>
+              <Text
+                style={[
+                  styles.sectionLabel,
+                  { color: c.textLight, marginTop: spacing.lg },
+                ]}
+              >
                 {t.auth.selectClass}
               </Text>
               <ScrollView
@@ -218,78 +220,87 @@ export function GenerateCodesSheet({
                 contentContainerStyle={styles.chipsRow}
                 keyboardShouldPersistTaps="handled"
               >
-                <Pressable
+                <Chip
+                  label={t.psychologist.codeAny}
+                  active={classLetter === null}
                   onPress={() => {
                     hapticLight();
                     setClassLetter(null);
                   }}
-                  style={[
-                    styles.chip,
-                    {
-                      backgroundColor:
-                        classLetter === null ? c.primary : c.surfaceSecondary,
-                    },
-                  ]}
-                >
-                  <Text
-                    variant="small"
-                    style={{
-                      fontFamily: "DMSans-SemiBold",
-                      color: classLetter === null ? "#FFF" : c.textLight,
-                    }}
-                  >
-                    {t.psychologist.codeAny}
-                  </Text>
-                </Pressable>
+                  c={c}
+                />
                 {CLASS_LETTERS.map((l) => (
-                  <Pressable
+                  <Chip
                     key={l}
+                    label={l}
+                    active={classLetter === l}
                     onPress={() => {
                       hapticLight();
                       setClassLetter(classLetter === l ? null : l);
                     }}
-                    style={[
-                      styles.chip,
-                      {
-                        backgroundColor:
-                          classLetter === l ? c.primary : c.surfaceSecondary,
-                      },
-                    ]}
-                  >
-                    <Text
-                      variant="small"
-                      style={{
-                        fontFamily: "DMSans-SemiBold",
-                        color: classLetter === l ? "#FFF" : c.textLight,
-                      }}
-                    >
-                      {l}
-                    </Text>
-                  </Pressable>
+                    c={c}
+                  />
                 ))}
               </ScrollView>
             </ScrollView>
 
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                generateMutation.mutate();
-              }}
-              disabled={!canSubmit}
-              style={[
-                styles.submitBtn,
-                { backgroundColor: canSubmit ? c.primary : `${c.primary}60` },
-              ]}
-            >
-              {generateMutation.isPending && (
-                <ActivityIndicator size="small" color="#FFF" />
-              )}
-              <Text style={styles.submitText}>{t.psychologist.generate}</Text>
-            </Pressable>
+            <View style={[styles.footer, { borderTopColor: c.borderLight }]}>
+              <Pressable
+                onPress={() => {
+                  hapticLight();
+                  generateMutation.mutate();
+                }}
+                disabled={!canSubmit}
+                style={[
+                  styles.submitBtn,
+                  { backgroundColor: c.primary },
+                  !canSubmit && { opacity: 0.5 },
+                ]}
+              >
+                {generateMutation.isPending && (
+                  <ActivityIndicator size="small" color="#FFF" />
+                )}
+                <Text style={styles.submitText}>{t.psychologist.generate}</Text>
+              </Pressable>
+            </View>
           </View>
         </View>
       </KeyboardAvoidingView>
     </Modal>
+  );
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+  c,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+  c: ReturnType<typeof useThemeColors>;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.chip,
+        active
+          ? { backgroundColor: ds.brandSoft, borderColor: `${c.primary}33` }
+          : { backgroundColor: c.surfaceSecondary, borderColor: c.borderLight },
+      ]}
+    >
+      <Text
+        style={{
+          fontSize: 13,
+          fontFamily: "Inter_600SemiBold",
+          color: active ? c.primaryDark : c.textLight,
+        }}
+      >
+        {label}
+      </Text>
+    </Pressable>
   );
 }
 
@@ -303,15 +314,14 @@ const styles = StyleSheet.create({
     backgroundColor: "rgba(0,0,0,0.4)",
   },
   sheet: {
-    borderTopLeftRadius: radius.xl,
-    borderTopRightRadius: radius.xl,
-    paddingHorizontal: 20,
-    paddingTop: 8,
-    paddingBottom: 24,
+    borderTopLeftRadius: radius["3xl"],
+    borderTopRightRadius: radius["3xl"],
+    maxHeight: "85%",
   },
   handleWrap: {
     alignItems: "center",
-    paddingVertical: 8,
+    paddingTop: 10,
+    paddingBottom: 4,
   },
   handle: {
     width: 40,
@@ -321,48 +331,75 @@ const styles = StyleSheet.create({
   headerRow: {
     flexDirection: "row",
     alignItems: "center",
-    justifyContent: "space-between",
-    marginBottom: 12,
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
+  },
+  closeBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    paddingHorizontal: spacing.xl,
+    maxHeight: 480,
+  },
+  bodyContent: {
+    paddingBottom: spacing.lg,
   },
   sectionLabel: {
-    marginTop: 12,
-    marginBottom: 8,
+    fontSize: 11,
+    lineHeight: 14,
+    fontFamily: "Inter_600SemiBold",
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    marginBottom: spacing.sm,
   },
   namesInput: {
     minHeight: 110,
-    padding: 12,
+    padding: spacing.md,
     borderRadius: radius.md,
     borderWidth: 1,
   },
   namesText: {
     fontSize: 14,
-    fontFamily: "DMSans-Regular",
+    fontFamily: "Inter_400Regular",
     padding: 0,
     minHeight: 90,
   },
   chipsRow: {
-    gap: 6,
+    gap: spacing.sm,
     flexDirection: "row",
     alignItems: "center",
-    paddingRight: 12,
+    paddingRight: spacing.md,
   },
   chip: {
-    paddingHorizontal: 12,
-    paddingVertical: 6,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 8,
     borderRadius: 999,
+    borderWidth: 1,
+  },
+  footer: {
+    paddingHorizontal: spacing.xl,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.xl,
+    borderTopWidth: 1,
   },
   submitBtn: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
     gap: 8,
-    paddingVertical: 14,
-    borderRadius: radius.md,
-    marginTop: 16,
+    height: 48,
+    borderRadius: radius.lg,
   },
   submitText: {
     color: "#FFF",
-    fontSize: 14,
-    fontFamily: "DMSans-SemiBold",
+    fontSize: 15,
+    fontFamily: "Inter_700Bold",
+    letterSpacing: 0.2,
   },
 });


### PR DESCRIPTION
Closes #89, #90, #91, #92, #93, #94, #95.

Финальный проход редизайна — детальные экраны и UI-кусочки (модалки, шиты, фильтры).

## Mobile (psy-mobapp)

### M1 · Detail screens (#90)
- **TestDetail**: brand-tinted hero (иконка + name + description + meta-pills inline), inline CTAs (primary fill + outlined secondary), tips-trigger открывает HelpSheet
- **AssignToStudent / AssignToClass**: Stepper из 3 шагов (выбор → детали → preview), preview-карточка с PreviewRow
- **DirectChat**: DayDivider между разными днями, time-separator при first-of-day и >5min gap, плотные bubbles (12/8 padding, gap 3)

### M2 · Crisis resolve + OfficeHours (#91)
- **CrisisResolve**: усиленный hero (avatar 48 + name 17/700 + eyebrow + summary), Action/Notes eyebrow, success-coloured CTA
- **OfficeHours**: visual weekly grid (2-col) вместо form-list, Today/Tomorrow preview сверху (brand-soft для рабочих дней), inline "Добавить" CTA в overrides header

### M3 · Profile + Onboarding (#92)
- **Profile**: identity hero + единая settings card (lang switcher + version в одном listcard), Logout как danger-row
- **Onboarding**: Stepper из 3 шагов вместо progress-bar и "1 из 3"

### M4 · Sheets / Filters / Dialogs (#93)
Унифицированная структура для всех bottom-sheets: handle bar 40x4 → header (title 18/700 + circle close-btn) → body ScrollView → sticky footer.
- активные chip-состояния через brand-soft + brand-deep вместо filled brand
- DMSans (нерабочий по ADR-008/015) → Inter везде
- ConfirmDialog: иконка сверху (alert-circle/help-circle), centered, danger/primary варианты

## Web (psy-app)

### W1 · StudentDetail внутренние секции (#94)
- **AssignmentsSegment / ResultsSegment**: переход на DataTable (density=compact)
- **AiReportCard**: нейтральный bg-surface вместо bg-white, header брендинг через brand-soft вместо indigo gradient, summary 16/600 (повышена иерархия)
- **AchievementsStack**: counter text-light вместо warning, hierarchy улучшена
- **StudentDetailHero**: убран gradient-to-br, avatar bg-brand-soft вместо filled brand
- **StudentTimeline**: фильтры brand-soft active вместо filled brand
- **PendingList**: иерархия (имя 14/600 → код mono → meta 11/light)

### W2 · Sheets / Filters / Dialogs (#95)
- **DiagnosticsFiltersSheet**: bottom-sheet → центрированная модалка max-w-lg
- **GenerateCodesSheet**: то же
- **ConfirmDialog**: иконка сверху + centered layout

## Принципы (#73)

1. ✅ Иерархия через размер, не только цвет — все hero/section заголовки 18-22/600+
2. ✅ Brand-teal только для CTA — везде где было декоративное использование заменено на brand-soft accent или нейтральный
3. ✅ Один декоративный приём — brand-tinted gradient на heroes (TestDetail mobile)
4. ✅ Web и mobile намеренно расходятся — на web filters/codes стали центрированными модалками, mobile остался bottom-sheet
5. ✅ Density: mobile разреженный → плотнее (chat 12/8 padding, gap 3); web структура через DataTable

## Verification

- `tsc` mobile: 19 errors (все pre-existing, baseline неизменен)
- `tsc` web: 16 errors (все pre-existing)
- `vite build` web: ✓ зелёный
- Не введено новых i18n ключей

## Test plan

- [ ] Запустить psy-mobapp в Expo Go, проверить все 4 mobile-экрана
- [ ] Открыть Stepper-экраны (assign-student, assign-class, onboarding)
- [ ] Проверить DayDivider в DirectChat при сообщениях из разных дней
- [ ] Открыть OfficeHours, проверить weekly grid и preview
- [ ] Открыть Profile, проверить identity hero и Logout danger-row
- [ ] Открыть все 4 sheets (Filters/Codes/Intervals/Override) на mobile, проверить унифицированную структуру
- [ ] На web — открыть Diagnostics → Assignments/Results, проверить DataTable
- [ ] На web — открыть AI-анализ модалку, проверить нейтральные цвета
- [ ] На web — открыть Diagnostics filters / Generate codes (центрированная модалка)
- [ ] ConfirmDialog: triggered logout/revoke/cancel-assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)