### PR TITLE
feat(backend): AI-отчёт диагностики — клинический контекст, zod, prompt versioning (closes #101)

### DIFF
--- a/drizzle/0017_diagnostic_ai_reports_prompt_version.sql
+++ b/drizzle/0017_diagnostic_ai_reports_prompt_version.sql
@@ -1,0 +1,6 @@
+-- Issue #101: persist the prompt version each AI report was generated under.
+-- We bump PROMPT_VERSION in code whenever the system prompt or payload schema
+-- materially changes; keeping the value alongside the report makes runtime
+-- behaviour reproducible when investigating a complaint. Existing reports
+-- remain NULL — only newly generated reports record their version.
+ALTER TABLE "diagnostic_ai_reports" ADD COLUMN "prompt_version" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780531200000,
       "tag": "0016_push_tokens",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1780790400000,
+      "tag": "0017_diagnostic_ai_reports_prompt_version",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/backend/src/db/schema.ts
+++ b/packages/backend/src/db/schema.ts
@@ -182,6 +182,7 @@ export const diagnosticAiReports = pgTable("diagnostic_ai_reports", {
   flaggedItems: jsonb("flagged_items"), // [{ questionIndex, reason }]
   tokensUsed: integer("tokens_used"),
   errorMessage: text("error_message"),
+  promptVersion: text("prompt_version"), // bumped when prompt/schema changes
   generatedAt: timestamp("generated_at", { withTimezone: true }),
   createdAt: timestamp("created_at", { withTimezone: true })
     .defaultNow()

--- a/packages/backend/src/modules/diagnostics/ai-report.service.test.ts
+++ b/packages/backend/src/modules/diagnostics/ai-report.service.test.ts
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
   createAiReportService,
   createReportLanguageResolver,
+  PROMPT_VERSION,
   type AiReportServiceDeps,
   type PersistedReport,
   type PersistedSession,
@@ -456,4 +457,225 @@ test("generateReport: writes status=ready with parsed LLM payload for completed 
   assert.equal(report.errorMessage, null);
   assert.ok(report.generatedAt instanceof Date);
   assert.equal(fakes.llmCalls.length, 1);
+});
+
+// ─── Issue #101: clinical context, server flagged items, zod, prompt version ─
+
+test("generateReport: userPayload includes clinicalContext from test.scoringRules", async () => {
+  const scoringRules = {
+    thresholds: [
+      { min: 0, max: 4, severity: "minimal" },
+      { min: 5, max: 9, severity: "mild" },
+      { min: 10, max: 14, severity: "moderate" },
+      { min: 15, max: 27, severity: "severe" },
+    ],
+    maxScore: 27,
+    maxOptionValue: 3,
+    minOptionValue: 0,
+    flaggedRules: [
+      { questionIndex: 8, minAnswer: 1, reason: "suicidal_ideation" },
+    ],
+  };
+  const { service, fakes } = makeService({
+    fakes: {
+      tests: [
+        {
+          id: "test-1",
+          slug: "phq-a",
+          nameRu: "PHQ-A",
+          description: "Депрессия",
+          questions: [],
+          scoringRules,
+        },
+      ],
+    },
+  });
+
+  await service.generateReport("sess-1");
+
+  assert.equal(fakes.llmCalls.length, 1);
+  const payload = fakes.llmCalls[0].userPayload as {
+    clinicalContext: {
+      thresholds: unknown;
+      maxScore: number;
+      flaggedRules: unknown;
+    };
+  };
+  assert.deepEqual(payload.clinicalContext.thresholds, scoringRules.thresholds);
+  assert.equal(payload.clinicalContext.maxScore, 27);
+  assert.deepEqual(
+    payload.clinicalContext.flaggedRules,
+    scoringRules.flaggedRules,
+  );
+});
+
+test("generateReport: userPayload.result.serverFlaggedItems comes from session.flaggedItems", async () => {
+  const serverFlagged = [
+    { questionIndex: 8, answer: 2, reason: "suicidal_ideation" },
+  ];
+  const { service, fakes } = makeService({
+    fakes: {
+      sessions: [
+        {
+          id: "sess-1",
+          userId: "stu-1",
+          testId: "test-1",
+          assignmentId: null,
+          totalScore: 12,
+          maxScore: 27,
+          severity: "moderate",
+          completedAt: new Date("2026-04-25T08:00:00.000Z"),
+          flaggedItems: serverFlagged,
+        },
+      ],
+    },
+  });
+
+  await service.generateReport("sess-1");
+
+  const payload = fakes.llmCalls[0].userPayload as {
+    result: { serverFlaggedItems: unknown };
+  };
+  assert.deepEqual(payload.result.serverFlaggedItems, serverFlagged);
+});
+
+test("generateReport: when serverFlaggedItems present, system prompt instructs to mirror them as high-severity riskFactors", async () => {
+  const { service, fakes } = makeService({
+    fakes: {
+      sessions: [
+        {
+          id: "sess-1",
+          userId: "stu-1",
+          testId: "test-1",
+          assignmentId: null,
+          totalScore: 12,
+          maxScore: 27,
+          severity: "moderate",
+          completedAt: new Date("2026-04-25T08:00:00.000Z"),
+          flaggedItems: [
+            { questionIndex: 8, answer: 2, reason: "suicidal_ideation" },
+          ],
+        },
+      ],
+    },
+  });
+
+  await service.generateReport("sess-1");
+
+  assert.match(
+    fakes.llmCalls[0].systemPrompt,
+    /serverFlaggedItems[\s\S]*riskFactors[\s\S]*high/i,
+  );
+});
+
+test("generateReport: when serverFlaggedItems empty, system prompt does not include the mirror-as-high directive", async () => {
+  const { service, fakes } = makeService();
+  await service.generateReport("sess-1");
+  assert.doesNotMatch(
+    fakes.llmCalls[0].systemPrompt,
+    /serverFlaggedItems/i,
+  );
+});
+
+test("generateReport: serverFlaggedItems defaults to [] when session.flaggedItems is null/missing", async () => {
+  const { service, fakes } = makeService();
+  await service.generateReport("sess-1");
+  const payload = fakes.llmCalls[0].userPayload as {
+    result: { serverFlaggedItems: unknown };
+  };
+  assert.deepEqual(payload.result.serverFlaggedItems, []);
+});
+
+test("generateReport: when LLM returns malformed JSON (riskFactors as string), writes status=error with Invalid LLM output", async () => {
+  const { service, fakes } = makeService({
+    llmResponse: {
+      content: JSON.stringify({
+        summary: "ok",
+        interpretation: "ok",
+        riskFactors: "not an array",
+        recommendations: [],
+        trend: null,
+        flaggedItems: [],
+      }),
+      tokensUsed: 50,
+    },
+  });
+
+  await service.generateReport("sess-1");
+
+  const report = fakes.reports[0];
+  assert.equal(report.status, "error");
+  assert.match(report.errorMessage ?? "", /Invalid LLM output/);
+  // Should NOT silently write partial payload
+  assert.equal(report.summary, null);
+  assert.equal(report.riskFactors, null);
+});
+
+test("generateReport: success path writes promptVersion equal to PROMPT_VERSION constant", async () => {
+  const llmContent = JSON.stringify({
+    summary: "ok",
+    interpretation: "ok",
+    riskFactors: [],
+    recommendations: [],
+    trend: null,
+    flaggedItems: [],
+  });
+  const { service, fakes } = makeService({
+    llmResponse: { content: llmContent, tokensUsed: 10 },
+  });
+  await service.generateReport("sess-1");
+  const report = fakes.reports[0];
+  assert.equal(report.status, "ready");
+  assert.equal(report.promptVersion, PROMPT_VERSION);
+});
+
+test("generateReport: when test.scoringRules is missing, clinicalContext is null and report still succeeds", async () => {
+  const llmContent = JSON.stringify({
+    summary: "ok",
+    interpretation: "ok",
+    riskFactors: [],
+    recommendations: [],
+    trend: null,
+    flaggedItems: [],
+  });
+  const { service, fakes } = makeService({
+    llmResponse: { content: llmContent, tokensUsed: 1 },
+    fakes: {
+      tests: [
+        {
+          id: "test-1",
+          slug: "phq-a",
+          nameRu: "PHQ-A",
+          description: null,
+          questions: [],
+          // scoringRules is intentionally omitted
+        },
+      ],
+    },
+  });
+  await service.generateReport("sess-1");
+  const payload = fakes.llmCalls[0].userPayload as {
+    clinicalContext: unknown;
+  };
+  assert.equal(payload.clinicalContext, null);
+  assert.equal(fakes.reports[0].status, "ready");
+});
+
+test("generateReport: when LLM returns invalid recommendation type, writes status=error", async () => {
+  const { service, fakes } = makeService({
+    llmResponse: {
+      content: JSON.stringify({
+        summary: "ok",
+        interpretation: "ok",
+        riskFactors: [],
+        recommendations: [{ type: "bogus", text: "x" }],
+        trend: null,
+        flaggedItems: [],
+      }),
+      tokensUsed: 50,
+    },
+  });
+  await service.generateReport("sess-1");
+  assert.equal(fakes.reports[0].status, "error");
+  assert.match(fakes.reports[0].errorMessage ?? "", /Invalid LLM output/);
 });

--- a/packages/backend/src/modules/diagnostics/ai-report.service.ts
+++ b/packages/backend/src/modules/diagnostics/ai-report.service.ts
@@ -1,29 +1,44 @@
-interface RiskFactor {
-  factor: string;
-  severity: "low" | "moderate" | "high";
-  evidence?: string;
-}
+import { z } from "zod";
 
-interface Recommendation {
-  type: "therapy" | "exercise" | "referral" | "monitoring" | "conversation";
-  text: string;
-}
+const reportPayloadSchema = z.object({
+  summary: z.string(),
+  interpretation: z.string(),
+  riskFactors: z.array(
+    z.object({
+      factor: z.string(),
+      severity: z.enum(["low", "moderate", "high"]),
+      evidence: z.string().optional(),
+    }),
+  ),
+  recommendations: z.array(
+    z.object({
+      type: z.enum([
+        "therapy",
+        "exercise",
+        "referral",
+        "monitoring",
+        "conversation",
+      ]),
+      text: z.string(),
+    }),
+  ),
+  trend: z.string().nullable(),
+  flaggedItems: z.array(
+    z.object({
+      questionIndex: z.number(),
+      reason: z.string(),
+    }),
+  ),
+});
 
-interface FlaggedItem {
-  questionIndex: number;
-  reason: string;
-}
-
-interface ReportPayload {
-  summary: string;
-  interpretation: string;
-  riskFactors: RiskFactor[];
-  recommendations: Recommendation[];
-  trend: string | null;
-  flaggedItems: FlaggedItem[];
-}
+type ReportPayload = z.infer<typeof reportPayloadSchema>;
 
 export const REPORT_MODEL = "gpt-4.1-mini";
+
+// Bump when the system prompt or payload schema materially changes — old
+// reports keep the version they were generated under, so we can reproduce
+// behaviour when investigating a complaint.
+export const PROMPT_VERSION = "v2";
 
 export type ReportLanguage = "ru" | "kz";
 
@@ -43,6 +58,7 @@ export type PersistedReport = {
   generatedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
+  promptVersion?: string | null;
 };
 
 export type PersistedSession = {
@@ -54,6 +70,7 @@ export type PersistedSession = {
   maxScore: number | null;
   severity: string | null;
   completedAt: Date | null;
+  flaggedItems?: unknown;
 };
 
 export type PersistedTest = {
@@ -62,6 +79,7 @@ export type PersistedTest = {
   nameRu: string;
   description: string | null;
   questions: unknown;
+  scoringRules?: unknown;
 };
 
 export type PersistedAnswer = {
@@ -90,6 +108,7 @@ export type ReportUpdateFields = Partial<{
   tokensUsed: number | null;
   errorMessage: string | null;
   generatedAt: Date | null;
+  promptVersion: string | null;
 }>;
 
 export type LlmCall = (input: {
@@ -136,11 +155,38 @@ export type AiReportServiceDeps = {
   now: () => Date;
 };
 
-export function buildSystemPrompt(language: ReportLanguage): string {
+type ClinicalContext = {
+  thresholds: unknown;
+  maxScore: number | null;
+  flaggedRules: unknown;
+} | null;
+
+export function buildClinicalContext(scoringRules: unknown): ClinicalContext {
+  if (!scoringRules || typeof scoringRules !== "object") return null;
+  const sr = scoringRules as {
+    thresholds?: unknown;
+    maxScore?: unknown;
+    flaggedRules?: unknown;
+  };
+  return {
+    thresholds: Array.isArray(sr.thresholds) ? sr.thresholds : [],
+    maxScore: typeof sr.maxScore === "number" ? sr.maxScore : null,
+    flaggedRules: Array.isArray(sr.flaggedRules) ? sr.flaggedRules : [],
+  };
+}
+
+export function buildSystemPrompt(
+  language: ReportLanguage,
+  opts: { hasServerFlaggedItems?: boolean } = {},
+): string {
   const langDirective =
     language === "kz"
       ? "ҚАЗАҚ тілінде жаз — мектеп психологы үшін есеп құжат, оның интерфейсі қазақ тілінде."
       : "Пиши на РУССКОМ языке — отчёт для школьного психолога с русскоязычным интерфейсом.";
+
+  const serverFlaggedDirective = opts.hasServerFlaggedItems
+    ? `\n- result.serverFlaggedItems — это пункты, помеченные сервером по клиническим правилам (например, суицидальные мысли). КАЖДЫЙ такой пункт ОБЯЗАТЕЛЬНО отрази в riskFactors с severity = "high" и в flaggedItems с тем же questionIndex.`
+    : "";
 
   return `Ты — клинический психолог-ассистент, который помогает школьному психологу интерпретировать результаты психодиагностического теста ученика.
 
@@ -148,13 +194,15 @@ export function buildSystemPrompt(language: ReportLanguage): string {
 
 Язык отчёта: ${langDirective}
 
+Используй clinicalContext.thresholds (диапазоны баллов и их severity-уровни) и clinicalContext.maxScore как клинические нормы теста. Не выдумывай симптомы, которых нет в вопросах: ссылайся в evidence только на реально присутствующие answers[].questionIndex. Severity в riskFactors должна быть согласована с серверным result.severity.
+
 Требования:
 - Только JSON по указанной схеме, без markdown и лишнего текста.
 - Используй профессиональный, но не пугающий язык.
 - Не ставь диагнозов. Формулируй как "признаки", "симптомы совместимы с", "следует обратить внимание".
 - Рекомендации — практичные, применимые в школьной среде. Типы: "therapy" (индивидуальная беседа), "exercise" (упражнения: дыхание, заземление, дневник), "referral" (направление к специалисту), "monitoring" (наблюдение и повторная оценка), "conversation" (разговор с психологом/родителями).
 - riskFactors.severity: "low" | "moderate" | "high".
-- flaggedItems — это questionIndex тех пунктов, ответы на которые особенно тревожны (например, вопросы о суицидальных мыслях или самоповреждении с высоким значением). Если таких нет — пустой массив.
+- flaggedItems — это questionIndex тех пунктов, ответы на которые особенно тревожны (например, вопросы о суицидальных мыслях или самоповреждении с высоким значением). Если таких нет — пустой массив.${serverFlaggedDirective}
 - trend: если previousResults непуст — кратко сравни с предыдущей попыткой ("ухудшение", "улучшение", "стабильно"). Если пуст — верни null.
 - summary — 1-2 предложения, самая суть.
 - interpretation — 3-6 предложений с клинической интерпретацией скора и ключевых паттернов в ответах.
@@ -246,12 +294,18 @@ export function createAiReportService(deps: AiReportServiceDeps) {
           };
         });
 
+        const clinicalContext = buildClinicalContext(test.scoringRules);
+        const serverFlaggedItems = Array.isArray(session.flaggedItems)
+          ? session.flaggedItems
+          : [];
+
         const userPayload = {
           test: {
             slug: test.slug,
             name: test.nameRu,
             description: test.description,
           },
+          clinicalContext,
           student: {
             name: student?.name ?? null,
             grade: student?.grade ?? null,
@@ -262,6 +316,7 @@ export function createAiReportService(deps: AiReportServiceDeps) {
             maxScore: session.maxScore,
             severity: session.severity,
             completedAt: session.completedAt?.toISOString() ?? null,
+            serverFlaggedItems,
           },
           previousResults: history.map((h) => ({
             totalScore: h.totalScore,
@@ -273,32 +328,36 @@ export function createAiReportService(deps: AiReportServiceDeps) {
           reportLanguage: language,
         };
 
-        const systemPrompt = buildSystemPrompt(language);
+        const systemPrompt = buildSystemPrompt(language, {
+          hasServerFlaggedItems: serverFlaggedItems.length > 0,
+        });
 
         const { content, tokensUsed } = await deps.callLLM({
           systemPrompt,
           userPayload,
         });
 
-        const parsed = JSON.parse(content || "{}") as Partial<ReportPayload>;
-
-        const payload: ReportPayload = {
-          summary: typeof parsed.summary === "string" ? parsed.summary : "",
-          interpretation:
-            typeof parsed.interpretation === "string" ? parsed.interpretation : "",
-          riskFactors: Array.isArray(parsed.riskFactors) ? parsed.riskFactors : [],
-          recommendations: Array.isArray(parsed.recommendations)
-            ? parsed.recommendations
-            : [],
-          trend: typeof parsed.trend === "string" ? parsed.trend : null,
-          flaggedItems: Array.isArray(parsed.flaggedItems)
-            ? parsed.flaggedItems
-            : [],
-        };
+        let raw: unknown;
+        try {
+          raw = JSON.parse(content || "{}");
+        } catch (parseErr) {
+          const msg = parseErr instanceof Error ? parseErr.message : String(parseErr);
+          throw new Error(`Invalid LLM output: not JSON (${msg})`);
+        }
+        const validated = reportPayloadSchema.safeParse(raw);
+        if (!validated.success) {
+          throw new Error(
+            `Invalid LLM output: ${validated.error.issues
+              .map((i) => `${i.path.join(".") || "<root>"}: ${i.message}`)
+              .join("; ")}`,
+          );
+        }
+        const payload: ReportPayload = validated.data;
 
         await deps.updateReport(sessionId, {
           status: "ready",
           model: REPORT_MODEL,
+          promptVersion: PROMPT_VERSION,
           summary: payload.summary,
           interpretation: payload.interpretation,
           riskFactors: payload.riskFactors,

--- a/packages/backend/src/modules/diagnostics/ai-report.singleton.ts
+++ b/packages/backend/src/modules/diagnostics/ai-report.singleton.ts
@@ -122,6 +122,7 @@ const realDeps: AiReportServiceDeps = {
         maxScore: diagnosticSessions.maxScore,
         severity: diagnosticSessions.severity,
         completedAt: diagnosticSessions.completedAt,
+        flaggedItems: diagnosticSessions.flaggedItems,
       })
       .from(diagnosticSessions)
       .where(eq(diagnosticSessions.id, id))
@@ -136,6 +137,7 @@ const realDeps: AiReportServiceDeps = {
         nameRu: diagnosticTests.nameRu,
         description: diagnosticTests.description,
         questions: diagnosticTests.questions,
+        scoringRules: diagnosticTests.scoringRules,
       })
       .from(diagnosticTests)
       .where(eq(diagnosticTests.id, id))

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -142,6 +142,7 @@ export interface DiagnosticAiReport {
   sessionId: string;
   status: AiReportStatus;
   model: string | null;
+  promptVersion: string | null;
   summary: string | null;
   interpretation: string | null;
   riskFactors: AiReportRiskFactor[] | null;


### PR DESCRIPTION
## Summary
- payload получает `clinicalContext` (thresholds, maxScore, flaggedRules) из `test.scoringRules` — LLM перестаёт галлюцинировать «вне теста»
- `payload.result.serverFlaggedItems` из `session.flaggedItems` + условная директива в промпте отразить их как `severity: high` — серверные критические сигналы (PHQ-A q8 и т.п.) не пропускаются
- `zod.safeParse` на LLM-output: при невалидном ответе → `status: error` + `Invalid LLM output: <issues>`, без silent fallback на пустые массивы
- `PROMPT_VERSION = "v2"` + миграция 0017 (`prompt_version` колонка) — будем знать, по какой версии инструкций сгенерирован отчёт
- 7 новых TDD-тестов в `ai-report.service.test.ts` (25/25 зелёные)

closes #101

## Test plan
- [ ] `cd packages/backend && npx tsx --test src/modules/diagnostics/ai-report.service.test.ts` — 25/25 проходят
- [ ] Применить миграцию 0017 на dev-БД, убедиться что колонка `prompt_version` появилась
- [ ] Сгенерировать новый AI-отчёт в UI психолога — `prompt_version` в БД = `v2`
- [ ] Старые отчёты остаются с `prompt_version = NULL` (миграция назад не делалась — это в скоупе issue не было)
- [ ] Поломать LLM-output вручную (например, временно вернуть мусор в `realCallLLM`) — отчёт должен уйти в `status: error` с осмысленным сообщением

🤖 Generated with [Claude Code](https://claude.com/claude-code)