### PR TITLE
feat(shared): API-методы reset-флоу (closes #106)

### DIFF
--- a/packages/backend/src/api-client/api-client.test.ts
+++ b/packages/backend/src/api-client/api-client.test.ts
@@ -406,3 +406,160 @@ test("psychologist.diagnostics.assignTest: studentMessage попадает в т
     studentMessage: "Пожалуйста, пройди этот тест на этой неделе",
   });
 });
+
+// ── auth.forgotPassword / verifyResetCode / resetPassword ───────────
+
+test("auth.forgotPassword: POST /auth/forgot-password с body {email}, парсит {success:true}", async () => {
+  const app = new Hono();
+  const calls: Array<{ method: string; path: string; body: unknown }> = [];
+  app.post("/auth/forgot-password", async (c) => {
+    calls.push({
+      method: "POST",
+      path: c.req.path,
+      body: await c.req.json().catch(() => null),
+    });
+    return c.json({ success: true });
+  });
+
+  const client = createTirekClient({
+    baseUrl: "http://test",
+    getToken: () => null,
+    fetch: makeFetch(app),
+  });
+
+  const result = await client.auth.forgotPassword({ email: "u@example.com" });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "POST");
+  assert.equal(calls[0].path, "/auth/forgot-password");
+  assert.deepEqual(calls[0].body, { email: "u@example.com" });
+  assert.deepEqual(result, { success: true });
+});
+
+test("auth.verifyResetCode: POST /auth/verify-reset-code с body {email,code}, парсит {valid:true}", async () => {
+  const app = new Hono();
+  const calls: Array<{ method: string; path: string; body: unknown }> = [];
+  app.post("/auth/verify-reset-code", async (c) => {
+    calls.push({
+      method: "POST",
+      path: c.req.path,
+      body: await c.req.json().catch(() => null),
+    });
+    return c.json({ valid: true });
+  });
+
+  const client = createTirekClient({
+    baseUrl: "http://test",
+    getToken: () => null,
+    fetch: makeFetch(app),
+  });
+
+  const result = await client.auth.verifyResetCode({
+    email: "u@example.com",
+    code: "123456",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "POST");
+  assert.equal(calls[0].path, "/auth/verify-reset-code");
+  assert.deepEqual(calls[0].body, { email: "u@example.com", code: "123456" });
+  assert.deepEqual(result, { valid: true });
+});
+
+test("auth.resetPassword: POST /auth/reset-password с {email,code,newPassword}, парсит AuthResponse (token+user)", async () => {
+  const app = new Hono();
+  const calls: Array<{ method: string; path: string; body: unknown }> = [];
+  app.post("/auth/reset-password", async (c) => {
+    calls.push({
+      method: "POST",
+      path: c.req.path,
+      body: await c.req.json().catch(() => null),
+    });
+    return c.json({
+      token: "jwt-tok",
+      user: {
+        id: "u1",
+        email: "u@example.com",
+        name: "Aliya",
+        role: "student",
+        language: "ru",
+        avatarId: null,
+        grade: 9,
+        classLetter: "Б",
+        schoolId: null,
+        createdAt: "2026-05-04T10:00:00.000Z",
+      },
+    });
+  });
+
+  const client = createTirekClient({
+    baseUrl: "http://test",
+    getToken: () => null,
+    fetch: makeFetch(app),
+  });
+
+  const result = await client.auth.resetPassword({
+    email: "u@example.com",
+    code: "123456",
+    newPassword: "new-secret-123",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "POST");
+  assert.equal(calls[0].path, "/auth/reset-password");
+  assert.deepEqual(calls[0].body, {
+    email: "u@example.com",
+    code: "123456",
+    newPassword: "new-secret-123",
+  });
+  assert.equal(result.token, "jwt-tok");
+  assert.equal(result.user.id, "u1");
+  assert.equal(result.user.email, "u@example.com");
+});
+
+test("auth reset endpoints: при getToken=null Authorization header отсутствует", async () => {
+  const app = new Hono();
+  const seenAuth: string[] = [];
+  app.post("/auth/forgot-password", (c) => {
+    seenAuth.push(c.req.header("Authorization") ?? "");
+    return c.json({ success: true });
+  });
+  app.post("/auth/verify-reset-code", (c) => {
+    seenAuth.push(c.req.header("Authorization") ?? "");
+    return c.json({ valid: true });
+  });
+  app.post("/auth/reset-password", (c) => {
+    seenAuth.push(c.req.header("Authorization") ?? "");
+    return c.json({
+      token: "t",
+      user: {
+        id: "u1",
+        email: "u@example.com",
+        name: "x",
+        role: "student",
+        language: "ru",
+        avatarId: null,
+        grade: null,
+        classLetter: null,
+        schoolId: null,
+        createdAt: "2026-05-04T10:00:00.000Z",
+      },
+    });
+  });
+
+  const client = createTirekClient({
+    baseUrl: "http://test",
+    getToken: () => null,
+    fetch: makeFetch(app),
+  });
+
+  await client.auth.forgotPassword({ email: "a@b.c" });
+  await client.auth.verifyResetCode({ email: "a@b.c", code: "123456" });
+  await client.auth.resetPassword({
+    email: "a@b.c",
+    code: "123456",
+    newPassword: "new-pw-123",
+  });
+
+  assert.deepEqual(seenAuth, ["", "", ""]);
+});

--- a/packages/shared/src/api/index.ts
+++ b/packages/shared/src/api/index.ts
@@ -296,6 +296,16 @@ export interface TirekClient {
     }): Promise<AuthResponse>;
     me(): Promise<User>;
     updateProfile(input: Record<string, unknown>): Promise<User>;
+    forgotPassword(input: { email: string }): Promise<{ success: true }>;
+    verifyResetCode(input: {
+      email: string;
+      code: string;
+    }): Promise<{ valid: true }>;
+    resetPassword(input: {
+      email: string;
+      code: string;
+      newPassword: string;
+    }): Promise<AuthResponse>;
   };
 
   // ── Student-side ──────────────────────────────────────────────────
@@ -506,6 +516,21 @@ export function createTirekClient(opts: CreateTirekClientOptions): TirekClient {
       me: () => request("/auth/me"),
       updateProfile: (data) =>
         request("/auth/profile", { method: "PATCH", body: JSON.stringify(data) }),
+      forgotPassword: (data) =>
+        request("/auth/forgot-password", {
+          method: "POST",
+          body: JSON.stringify(data),
+        }),
+      verifyResetCode: (data) =>
+        request("/auth/verify-reset-code", {
+          method: "POST",
+          body: JSON.stringify(data),
+        }),
+      resetPassword: (data) =>
+        request("/auth/reset-password", {
+          method: "POST",
+          body: JSON.stringify(data),
+        }),
     },
 
     mood: {


### PR DESCRIPTION
## Summary

- В `@tirek/shared/api` добавлены три метода: `auth.forgotPassword`, `auth.verifyResetCode`, `auth.resetPassword`. Единый контракт для psy-mobapp и student-mobapp.
- Shapes согласованы с реальными бэкенд-эндпоинтами из #105 — `{success:true}`, `{valid:true}`, `AuthResponse` (для автологина).
- 4 integration-теста через in-process Hono: URL/method/body, парсинг ответов, отсутствие Authorization header при `getToken=null` (вызовы до логина).

## Notes

- Issue упоминал success-shape `{ok:true}`, но #105 уже зафиксировал `{success:true}` — взял реальный контракт.
- Методы добавлены в `client.auth.*` (issue писал `authApi.X`, но в shared это namespace `auth`; в mobapp есть тонкие re-exports).

## Test plan

- [x] `npx tsx --test src/api-client/api-client.test.ts` — 18/18 passing
- [x] Добавленные тесты проходят и до моих изменений падают как RED
- [x] TS-delta в psy-mobapp / student-mobapp = 0 (новых ошибок не привнёс; legacy-шум baseline есть и на main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)